### PR TITLE
fix: global.log throws on GNOME 50, use log.warn instead

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3808,7 +3808,7 @@ function _show_skip_taskbar_windows(ext: Ext) {
             return is_valid_minimize_to_tray(meta_win, ext) || base;
         };
     } else if (!WS_OVERVIEW_KEY) {
-        (global as any).log('O-Tiling: WARNING - Workspace overview method not found. Skip-taskbar feature disabled.');
+        log.warn('Workspace overview method not found. Skip-taskbar feature disabled.');
         return;
     }
 
@@ -3825,7 +3825,7 @@ function _show_skip_taskbar_windows(ext: Ext) {
             return app ? app.get_name() : '';
         };
     } else {
-        (global as any).log('O-Tiling: WARNING - WindowPreview._getCaption not found. Caption override skipped.');
+        log.warn('WindowPreview._getCaption not found. Caption override skipped.');
     }
 
     // Handle the workspace thumbnail


### PR DESCRIPTION
Hi,

while debugging a session crash on the Margine live ISO (GNOME 50, Fedora 44) I kept seeing this in the journal, fired every time a skip-taskbar window appeared (the Anaconda installer dialogs in my case):

```
JS ERROR: TypeError: global.log is not a function
_show_skip_taskbar_windows@.../o-tiling@oliwebd.github.com/extension.js:3234
```

global.log was removed from GNOME Shell a while ago, so on GNOME 50 the two WARNING branches in _show_skip_taskbar_windows throw instead of warning, and the handler aborts mid-run on every event.

This PR just switches the two calls to the in-tree log.warn, same as the rest of extension.ts. I dropped the manual 'O-Tiling: WARNING' prefix since the util already adds its own prefix and the level says the rest.

To be clear, this was not the cause of my crash (that turned out to be a gnome-desktop bug), but the throw is real and noisy on GNOME 50. We are hotfixing it downstream in Margine at build time until a release with the fix lands, so no rush on my side. v2.9.5 ships the broken calls.

Thanks for o-tiling, it is the heart of our desktop.
Daniel