### PR TITLE
Add workspace/window animation system, GNOME 49+ compatibility, and settings consolidation

### DIFF
--- a/icons/o-tiling-ws-overview-symbolic.svg
+++ b/icons/o-tiling-ws-overview-symbolic.svg
@@ -1,5 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.2" stroke-linecap="round" stroke-linejoin="round">
-  <path d="M12 12c-2-2.5-4-4-6-4a4 4 0 0 0 0 8c2 0 4-1.5 6-4z"/>
-  <path d="M12 12c2 2.5 4 4 6 4a4 4 0 0 0 0-8c-2 0-4 1.5-6 4z"/>
-</svg>

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "O-tiling",
     "description": "O-Tiling is a free, open-source auto-tiling extension for GNOME Shell 48, 49, and 50. It automatically organizes your open windows into a clean, tiled layout - no manual dragging needed. Built on a proven tiling engine with many new features on top.",
-    "version-name": "2.9.5",
+    "version-name": "2.9.7",
     "uuid": "o-tiling@oliwebd.github.com",
     "settings-schema": "org.gnome.shell.extensions.o-tiling",
     "shell-version": [

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "O-tiling",
     "description": "O-Tiling is a free, open-source auto-tiling extension for GNOME Shell 48, 49, and 50. It automatically organizes your open windows into a clean, tiled layout - no manual dragging needed. Built on a proven tiling engine with many new features on top.",
-    "version-name": "2.9.8",
+    "version-name": "2.9.9",
     "uuid": "o-tiling@oliwebd.github.com",
     "settings-schema": "org.gnome.shell.extensions.o-tiling",
     "shell-version": [

--- a/metadata.json
+++ b/metadata.json
@@ -1,7 +1,7 @@
 {
     "name": "O-tiling",
     "description": "O-Tiling is a free, open-source auto-tiling extension for GNOME Shell 48, 49, and 50. It automatically organizes your open windows into a clean, tiled layout - no manual dragging needed. Built on a proven tiling engine with many new features on top.",
-    "version-name": "2.9.7",
+    "version-name": "2.9.8",
     "uuid": "o-tiling@oliwebd.github.com",
     "settings-schema": "org.gnome.shell.extensions.o-tiling",
     "shell-version": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "o-tiling",
-  "version": "2.9.8",
+  "version": "2.9.9",
   "description": "Auto-tiling extension for GNOME Shell with 'Aura' focus border, customizable workspace overview styling, and theme consistency.",
   "author": "oliwebd",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "o-tiling",
-  "version": "2.9.5",
+  "version": "2.9.7",
   "description": "Auto-tiling extension for GNOME Shell with 'Aura' focus border, customizable workspace overview styling, and theme consistency.",
   "author": "oliwebd",
   "type": "module",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package",
   "name": "o-tiling",
-  "version": "2.9.7",
+  "version": "2.9.8",
   "description": "Auto-tiling extension for GNOME Shell with 'Aura' focus border, customizable workspace overview styling, and theme consistency.",
   "author": "oliwebd",
   "type": "module",

--- a/schemas/org.gnome.shell.extensions.o-tiling.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.o-tiling.gschema.xml
@@ -47,6 +47,16 @@
             <summary>Show a workspace number label (e.g. "2 / 4") in the panel instead of the dot indicator</summary>
         </key>
 
+        <key type="b" name="hide-panel-icon">
+            <default>false</default>
+            <summary>Hide the O-Tiling icon and menu from the top panel</summary>
+        </key>
+
+        <key type="b" name="quick-settings-toggle">
+            <default>false</default>
+            <summary>Show O-Tiling controls as a toggle in the GNOME Quick Settings menu instead of a dedicated panel icon</summary>
+        </key>
+
         <!-- Workspace Animation -->
         <key type="s" name="workspace-animation-style">
             <default>'none'</default>

--- a/schemas/org.gnome.shell.extensions.o-tiling.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.o-tiling.gschema.xml
@@ -53,6 +53,16 @@
             <summary>Workspace switch animation style: 'none' (default GNOME), 'slide' (windows slide, wallpaper static), 'swing' (Hyprland-style overshoot, wallpaper static)</summary>
         </key>
 
+        <key type="s" name="window-animation-style">
+            <default>'default'</default>
+            <summary>Window open/close/move/resize animation style: 'default' (native GNOME), 'hyprland' (bouncy overshoot, Hyprland/niri-like), 'none' (instant)</summary>
+        </key>
+
+        <key type="i" name="window-animation-duration">
+            <default>200</default>
+            <summary>Duration in milliseconds for window animations when style is not 'none'</summary>
+        </key>
+
         <key type="b" name="skip-overview">
             <default>false</default>
             <summary>Skip the activities overview on startup</summary>

--- a/schemas/org.gnome.shell.extensions.o-tiling.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.o-tiling.gschema.xml
@@ -47,6 +47,12 @@
             <summary>Show a workspace number label (e.g. "2 / 4") in the panel instead of the dot indicator</summary>
         </key>
 
+        <!-- Workspace Animation -->
+        <key type="s" name="workspace-animation-style">
+            <default>'none'</default>
+            <summary>Workspace switch animation style: 'none' (default GNOME), 'slide' (windows slide, wallpaper static), 'swing' (Hyprland-style overshoot, wallpaper static)</summary>
+        </key>
+
         <key type="b" name="skip-overview">
             <default>false</default>
             <summary>Skip the activities overview on startup</summary>

--- a/schemas/org.gnome.shell.extensions.o-tiling.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.o-tiling.gschema.xml
@@ -55,12 +55,12 @@
 
         <key type="s" name="window-animation-style">
             <default>'default'</default>
-            <summary>Window open/close/move/resize animation style: 'default' (native GNOME), 'hyprland' (bouncy overshoot, Hyprland/niri-like), 'none' (instant)</summary>
+            <summary>Window open/close/move/resize animation style: 'default' (native GNOME), 'hyprland' (bouncy overshoot, Hyprland/niri-like), 'glide' (smooth slide in/out)</summary>
         </key>
 
         <key type="i" name="window-animation-duration">
             <default>200</default>
-            <summary>Duration in milliseconds for window animations when style is not 'none'</summary>
+            <summary>Duration in milliseconds for window animations</summary>
         </key>
 
         <key type="b" name="skip-overview">

--- a/segfault.log
+++ b/segfault.log
@@ -1,0 +1,31 @@
+Fatal Python error: Segmentation fault
+
+Current thread 0x00007f774fb96bc0 [python] (most recent call first):
+  File "/usr/lib/python3.14/pathlib/__init__.py", line 654 in stat
+  File "/home/waleee/oliwebd/o-tiling/venv/lib/python3.14/site-packages/shexli/analyzer/safety.py", line 106 in read_text_with_limit
+  File "/home/waleee/oliwebd/o-tiling/venv/lib/python3.14/site-packages/shexli/analyzer/reachability.py", line 372 in reachable_js_contexts
+  File "/home/waleee/oliwebd/o-tiling/venv/lib/python3.14/site-packages/shexli/analyzer/core.py", line 162 in analyze_path
+  File "/home/waleee/oliwebd/o-tiling/venv/lib/python3.14/site-packages/shexli/cli.py", line 101 in main
+  File "<string>", line 1 in <module>
+
+Current thread's C stack trace (most recent call first):
+  Binary file "/usr/lib/libpython3.14.so.1.0", at _Py_DumpStack+0x4d [0x7f774f567ba1]
+  Binary file "/usr/lib/libpython3.14.so.1.0", at +0x16ce35 [0x7f774f56ce35]
+  Binary file "/usr/lib/libc.so.6", at +0x3e8f0 [0x7f774f03e8f0]
+  Binary file "/usr/lib/libpython3.14.so.1.0", at PyNumber_Add+0xa9 [0x7f774f633d59]
+  Binary file "/usr/lib/libpython3.14.so.1.0", at +0x2e5a21 [0x7f774f6e5a21]
+  Binary file "/usr/lib/libpython3.14.so.1.0", at +0x2e4330 [0x7f774f6e4330]
+  Binary file "/usr/lib/libpython3.14.so.1.0", at PyObject_Vectorcall+0x5d [0x7f774f5a78fd]
+  Binary file "/usr/lib/libpython3.14.so.1.0", at +0x68016 [0x7f774f468016]
+  Binary file "/usr/lib/libpython3.14.so.1.0", at +0x1b7952 [0x7f774f5b7952]
+  Binary file "/usr/lib/libpython3.14.so.1.0", at PyEval_EvalCode+0xb4 [0x7f774f6ba2c4]
+  Binary file "/usr/lib/libpython3.14.so.1.0", at +0x30391f [0x7f774f70391f]
+  Binary file "/usr/lib/libpython3.14.so.1.0", at +0x2fbccd [0x7f774f6fbccd]
+  Binary file "/usr/lib/libpython3.14.so.1.0", at +0x2fbbb3 [0x7f774f6fbbb3]
+  Binary file "/usr/lib/libpython3.14.so.1.0", at Py_RunMain+0x52f [0x7f774f6a80af]
+  Binary file "/usr/lib/libpython3.14.so.1.0", at Py_BytesMain+0x3c [0x7f774f6a1cfc]
+  Binary file "/usr/lib/libc.so.6", at +0x27741 [0x7f774f027741]
+  Binary file "/usr/lib/libc.so.6", at __libc_start_main+0x89 [0x7f774f027879]
+  Binary file "python", at _start+0x25 [0x563b9decf045]
+
+Extension modules: tree_sitter_javascript._binding (total: 1)

--- a/src/engine/forest.ts
+++ b/src/engine/forest.ts
@@ -6,7 +6,7 @@ import * as movement from '../window/movement.js';
 import * as Rect from '../utils/rectangle.js';
 import * as Node from './node.js';
 import * as Fork from './fork.js';
-import * as utils from '../utils/utils.js';
+
 import * as geom from '../utils/geom.js';
 
 import type { Entity } from '../core/ecs.js';

--- a/src/engine/forest.ts
+++ b/src/engine/forest.ts
@@ -945,7 +945,7 @@ function move_window(ext: Ext, window: ShellWindow, rect: Rectangle, on_complete
 
     if (!actor) {
         if (retries < 10) {
-            utils.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
+            Lib.later_add(Meta.LaterType.BEFORE_REDRAW, () => {
                 move_window(ext, window, rect, on_complete, retries + 1);
                 return GLib.SOURCE_REMOVE;
             });

--- a/src/engine/tiling.ts
+++ b/src/engine/tiling.ts
@@ -7,7 +7,7 @@ import * as Tags from '../utils/tags.js';
 import * as window from '../window/window.js';
 import * as geom from '../utils/geom.js';
 import * as exec from '../system/executor.js';
-import * as utils from '../utils/utils.js';
+
 
 import type { Entity } from '../core/ecs.js';
 import type { Rectangle } from '../utils/rectangle.js';

--- a/src/engine/tiling.ts
+++ b/src/engine/tiling.ts
@@ -748,8 +748,8 @@ export class Tiler {
 
             this.window = win.entity;
 
-            if (utils.is_maximized(win.meta)) {
-                utils.unmaximize(win.meta);
+            if (Lib.is_maximized(win.meta)) {
+                Lib.unmaximize(win.meta);
             }
 
             // Set overlay to match window

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1332,20 +1332,12 @@ export class Ext extends Ecs.System<ExtEvent> {
         } else {
             const focus = this.focus_window();
 
-            // Guard 1: focus is null and a panel/dock/popup actor holds Clutter key-focus
-            // (quick settings, calendar, notification centre, Dash-to-Dock) — preserve the
-            // existing border and do nothing.  The panel will dismiss and the window will
-            // regain focus naturally without us touching _bordered_entity.
+            // No focused window but a shell panel/popup holds key-focus — preserve existing border.
             if (!focus && Window.clutter_focus_is_shell_panel()) {
                 return;
             }
 
-            // Guard 2: same window already owns the active border — skip the full
-            // hide_all_borders + show_border cycle entirely.
-            // This covers two sub-cases:
-            //   a) focus entity matches _bordered_entity (normal same-window check).
-            //   b) focus is non-null, pointer is on panel/dock, and a border is already
-            //      active — panel hover should never steal or re-render the border.
+            // Same window already bordered, or panel hover with an active border — skip redraw.
             if (focus && this._bordered_entity === focus.entity) {
                 const b = focus.border;
                 if (b && b.visible) return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2476,11 +2476,6 @@ export class Ext extends Ecs.System<ExtEvent> {
                         _hide_skip_taskbar_windows();
                     }
                     break;
-                case 'log-level':
-                    if (indicator && indicator.toggle_debug) {
-                        indicator.toggle_debug.setToggleState(this.settings.log_level() === 4);
-                    }
-                    break;
 
             }
         });

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -33,6 +33,8 @@ import { Rectangle } from './utils/rectangle.js';
 import type { Indicator } from './ui/panel_settings.js';
 import type { WorkspaceNumberIndicator } from './ui/panel_settings.js';
 import { WorkspaceSwitcherStyle, isGnome50 } from './ui/workspace_switcher_style.js';
+import { WorkspaceAnimationManager } from './ui/workspace_animation.js';
+import type { AnimationStyle } from './ui/workspace_animation.js';
 import { ThemeConsistencyManager } from './ui/theme_consistency/index.js';
 import { PanelTransparencyManager } from './ui/panel_transparency.js';
 import { OverviewLayoutManager } from './ui/overview_layout.js';
@@ -213,6 +215,7 @@ export class Ext extends Ecs.System<ExtEvent> {
     auto_tiler: auto_tiler.AutoTiler | null = null; // Manages automatic tiling behaviors in the shell
 
     workspace_switcher_style_handler: WorkspaceSwitcherStyle | null = null; // Optional workspace-switcher re-style (GNOME 50+ only)
+    workspace_animation_handler: WorkspaceAnimationManager | null = null; // Optional static-wallpaper + window-swing animation
 
     focus_selector: Focus.FocusSelector = new Focus.FocusSelector(); // Performs focus selections
 
@@ -351,11 +354,15 @@ export class Ext extends Ecs.System<ExtEvent> {
         });
         this._settings_signal_ids.push([this.settings.ext, id_ws_num]);
 
-
+        // Workspace animation style — static wallpaper + window swing
+        const id_ws_anim = this.settings.ext.connect('changed::workspace-animation-style', () => {
+            this.toggle_workspace_animation(this.settings.workspace_animation_style() as AnimationStyle);
+        });
+        this._settings_signal_ids.push([this.settings.ext, id_ws_anim]);
 
         // Initial application
         this.toggle_workspace_switcher_style(this.settings.workspace_switcher_style(), false);
-
+        this.toggle_workspace_animation(this.settings.workspace_animation_style() as AnimationStyle, false);
         this.toggle_theme_consistency(this.settings.theme_consistency_style(), false);
         this.toggle_panel_transparency(this.settings.panel_transparency(), false);
 
@@ -477,6 +484,11 @@ export class Ext extends Ecs.System<ExtEvent> {
         if (this.workspace_switcher_style_handler) {
             this.workspace_switcher_style_handler.disable();
             this.workspace_switcher_style_handler = null;
+        }
+
+        if (this.workspace_animation_handler) {
+            this.workspace_animation_handler.disable();
+            this.workspace_animation_handler = null;
         }
 
         if (this.theme_consistency_handler) {
@@ -3096,6 +3108,25 @@ export class Ext extends Ecs.System<ExtEvent> {
     }
 
 
+
+    /** Enables / updates the workspace animation style (static wallpaper + window swing). */
+    toggle_workspace_animation(style: AnimationStyle, save: boolean = true) {
+        if (style === 'none') {
+            this.workspace_animation_handler?.disable();
+            this.workspace_animation_handler = null;
+        } else {
+            if (!this.workspace_animation_handler) {
+                this.workspace_animation_handler = new WorkspaceAnimationManager(style);
+                this.workspace_animation_handler.enable();
+            } else {
+                this.workspace_animation_handler.setStyle(style);
+            }
+        }
+
+        if (save) {
+            this.settings.set_workspace_animation_style(style);
+        }
+    }
 
     toggle_theme_consistency(style: string, save: boolean = true) {
         if (style !== 'default') {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3158,13 +3158,14 @@ export class Ext extends Ecs.System<ExtEvent> {
             }
             this.theme_consistency_handler.enable(style as any);
 
-            // Also apply GTK theme consistency
-            applyThemeConsistency(style as 'rounded' | 'sharp');
+            // Not awaited: runs from a settings-changed signal handler, not enable()/disable(),
+            // so there is no shell-lifecycle race. Errors are caught and logged inside.
+            void applyThemeConsistency(style as 'rounded' | 'sharp');
         } else {
             this.theme_consistency_handler?.disable();
             this.theme_consistency_handler = null;
-            // Restore GTK gtk.css files to stock (remove the O-Tiling block).
-            restoreGtkDefaults();
+            // Not awaited: same rationale as above — errors are caught and logged inside.
+            void restoreGtkDefaults();
         }
 
         if (save) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -35,6 +35,8 @@ import type { WorkspaceNumberIndicator } from './ui/panel_settings.js';
 import { WorkspaceSwitcherStyle, isGnome50 } from './ui/workspace_switcher_style.js';
 import { WorkspaceAnimationManager } from './ui/workspace_animation.js';
 import type { AnimationStyle } from './ui/workspace_animation.js';
+import { WindowAnimationManager } from './ui/window_animation.js';
+import type { WindowAnimationStyle } from './ui/window_animation.js';
 import { ThemeConsistencyManager } from './ui/theme_consistency/index.js';
 import { PanelTransparencyManager } from './ui/panel_transparency.js';
 import { OverviewLayoutManager } from './ui/overview_layout.js';
@@ -113,7 +115,7 @@ export class Ext extends Ecs.System<ExtEvent> {
 
     // State
 
-    animate_windows: boolean = true; // Animate window movements
+
 
     button: any = null;
     button_gio_icon_auto_on: any = null;
@@ -216,6 +218,7 @@ export class Ext extends Ecs.System<ExtEvent> {
 
     workspace_switcher_style_handler: WorkspaceSwitcherStyle | null = null; // Optional workspace-switcher re-style (GNOME 50+ only)
     workspace_animation_handler: WorkspaceAnimationManager | null = null; // Optional static-wallpaper + window-swing animation
+    window_animation_handler: WindowAnimationManager = new WindowAnimationManager();
 
     focus_selector: Focus.FocusSelector = new Focus.FocusSelector(); // Performs focus selections
 
@@ -360,9 +363,19 @@ export class Ext extends Ecs.System<ExtEvent> {
         });
         this._settings_signal_ids.push([this.settings.ext, id_ws_anim]);
 
+        const id_win_anim = this.settings.ext.connect('changed::window-animation-style', () => {
+            this.toggle_window_animation(this.settings.window_animation_style() as WindowAnimationStyle);
+        });
+        this._settings_signal_ids.push([this.settings.ext, id_win_anim]);
+
         // Initial application
         this.toggle_workspace_switcher_style(this.settings.workspace_switcher_style(), false);
         this.toggle_workspace_animation(this.settings.workspace_animation_style() as AnimationStyle, false);
+        this.window_animation_handler = new WindowAnimationManager(
+            this.settings.window_animation_style() as WindowAnimationStyle,
+            this.settings.window_animation_duration(),
+        );
+        this.window_animation_handler.enable();
         this.toggle_theme_consistency(this.settings.theme_consistency_style(), false);
         this.toggle_panel_transparency(this.settings.panel_transparency(), false);
 
@@ -491,6 +504,8 @@ export class Ext extends Ecs.System<ExtEvent> {
             this.workspace_animation_handler = null;
         }
 
+        this.window_animation_handler.disable();
+
         if (this.theme_consistency_handler) {
             this.theme_consistency_handler.disable();
             this.theme_consistency_handler = null;
@@ -590,12 +605,11 @@ export class Ext extends Ecs.System<ExtEvent> {
                         return;
                     }
 
-                    (actor as any).remove_all_transitions();
                     const { x, y, width, height } = movement;
 
-                    // On GNOME 50/Mutter 18, move_resize_frame handles both position and size atomically
-                    // The additional move_frame call would cause redundant compositor commits
-                    window.meta.move_resize_frame(true, x, y, width, height);
+                    this.window_animation_handler.applyMove(actor as any, x, y, width, height, () =>
+                        window.meta.move_resize_frame(true, x, y, width, height),
+                    );
 
                     this.monitors.insert(window.entity, [win.meta.get_monitor(), win.workspace_id()]);
 
@@ -3117,6 +3131,14 @@ export class Ext extends Ecs.System<ExtEvent> {
 
         if (save) {
             this.settings.set_workspace_animation_style(style);
+        }
+    }
+
+    toggle_window_animation(style: WindowAnimationStyle, save: boolean = true) {
+        this.window_animation_handler.setStyle(style);
+
+        if (save) {
+            this.settings.set_window_animation_style(style);
         }
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2997,7 +2997,9 @@ export class Ext extends Ecs.System<ExtEvent> {
             indicator.toggle_tiled.setToggleState(false);
             this._indicator_updating = false;
             if (indicator.toggle_tiled.updateIcon) indicator.toggle_tiled.updateIcon(false);
+            this._indicator_updating = true;
             indicator.toggle_workspace_tiled?.setToggleState(false);
+            this._indicator_updating = false;
         }
 
         this.prev_focused = [null, null];

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -453,6 +453,30 @@ export class Ext extends Ecs.System<ExtEvent> {
         };
     }
 
+    /** Disconnects all tracked meta-window signals (window_signals + size_signals) for
+     * an entity and destroys its ShellWindow. Shared by destroy() and ext_soft_disable()
+     * so the two teardown paths can't drift out of sync with each other. */
+    private teardown_window(entity: Entity) {
+        const win = this.windows.get(entity);
+        if (!win) return;
+
+        const win_sigs = this.window_signals.get(entity);
+        if (win_sigs) {
+            for (const sig of win_sigs) {
+                if (sig) win.meta.disconnect(sig);
+            }
+        }
+
+        const size_sigs = this.size_signals.get(entity);
+        if (size_sigs) {
+            for (const sig of size_sigs) {
+                if (sig) win.meta.disconnect(sig);
+            }
+        }
+
+        win.destroy();
+    }
+
     destroy() {
         this.unset_grab_op();
         this.executor.stop();
@@ -533,23 +557,7 @@ export class Ext extends Ecs.System<ExtEvent> {
 
         const entities = Array.from(this.windows.iter()).map(([e]) => e);
         for (const entity of entities) {
-            const win = this.windows.get(entity);
-            if (win) {
-                const win_sigs = this.window_signals.get(entity);
-                if (win_sigs) {
-                    for (const sig of win_sigs) {
-                        if (sig) win.meta.disconnect(sig);
-                    }
-                }
-                const size_sigs = this.size_signals.get(entity);
-                if (size_sigs) {
-                    for (const sig of size_sigs) {
-                        if (sig) win.meta.disconnect(sig);
-                    }
-                }
-
-                win.destroy();
-            }
+            this.teardown_window(entity);
         }
 
         // Clean up all generic timeouts tracked in the property map
@@ -2907,23 +2915,7 @@ export class Ext extends Ecs.System<ExtEvent> {
         // 2. Hide borders and disconnect window signals
         const entities = Array.from(this.windows.iter()).map(([e]) => e);
         for (const entity of entities) {
-            const win = this.windows.get(entity);
-            if (win) {
-                const win_sigs = this.window_signals.get(entity);
-                if (win_sigs) {
-                    for (const sig of win_sigs) {
-                        if (sig) win.meta.disconnect(sig);
-                    }
-                }
-                const size_sigs = this.size_signals.get(entity);
-                if (size_sigs) {
-                    for (const sig of size_sigs) {
-                        if (sig) win.meta.disconnect(sig);
-                    }
-                }
-
-                win.destroy();
-            }
+            this.teardown_window(entity);
             this.delete_entity(entity);
         }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -368,6 +368,11 @@ export class Ext extends Ecs.System<ExtEvent> {
         });
         this._settings_signal_ids.push([this.settings.ext, id_win_anim]);
 
+        const id_win_anim_dur = this.settings.ext.connect('changed::window-animation-duration', () => {
+            this.window_animation_handler.setDuration(this.settings.window_animation_duration());
+        });
+        this._settings_signal_ids.push([this.settings.ext, id_win_anim_dur]);
+
         // Initial application
         this.toggle_workspace_switcher_style(this.settings.workspace_switcher_style(), false);
         this.toggle_workspace_animation(this.settings.workspace_animation_style() as AnimationStyle, false);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1306,10 +1306,10 @@ export class Ext extends Ecs.System<ExtEvent> {
             ) {
                 if (prev.rect().contains(win.rect())) {
                     if (prev.is_maximized()) {
-                        utils.unmaximize(prev.meta);
+                        Lib.unmaximize(prev.meta);
                     }
                 } else if (prev.stack) {
-                    utils.unmaximize(prev.meta);
+                    Lib.unmaximize(prev.meta);
                     this.auto_tiler.forest.stacks.get(prev.stack)?.restack();
                 }
             }
@@ -1465,7 +1465,7 @@ export class Ext extends Ecs.System<ExtEvent> {
                     compare.is_maximized() &&
                     win.entity[0] !== compare.entity[0]
                 ) {
-                    utils.unmaximize(compare.meta);
+                    Lib.unmaximize(compare.meta);
                 }
             }
         }
@@ -1744,7 +1744,7 @@ export class Ext extends Ecs.System<ExtEvent> {
 
             if (this.auto_tiler) {
                 if (this.is_floating(win)) {
-                    utils.unmaximize(win.meta);
+                    Lib.unmaximize(win.meta);
                 }
 
                 this.register(Events.window_move(this, win, rect));
@@ -1752,7 +1752,7 @@ export class Ext extends Ecs.System<ExtEvent> {
                 win.move(this, rect, () => { });
                 // if the resulting dimensions of rect == next
                 if (rect.width == next_area.width && rect.height == next_area.height) {
-                    utils.maximize(win.meta);
+                    Lib.maximize(win.meta);
                 }
             }
         }
@@ -2594,7 +2594,7 @@ export class Ext extends Ecs.System<ExtEvent> {
                                 refocus_tiled_window();
                             } else {
                                 // This section fixes Steam's sub-menus.
-                                utils.activate_window(meta_window);
+                                Lib.activate_window(meta_window);
                             }
                         }
                     } else if (this.auto_tiler) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -718,7 +718,7 @@ export class Ext extends Ecs.System<ExtEvent> {
     }
 
     active_monitor(): number {
-        return (global as any).backend.get_current_logical_monitor()?.get_number() ?? 0;
+        return Lib.active_monitor_index();
     }
 
     active_window_list(): Array<Window.ShellWindow> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,6 +66,7 @@ const { GlobalEvent, WindowEvent } = Events;
 export let ext: Ext | null = null;
 export let indicator: Indicator | null = null;
 export let workspace_number_indicator: WorkspaceNumberIndicator | null = null;
+export let quick_settings_indicator: any = null;
 
 const { cursor_rect, is_keyboard_op, is_resize_op, is_move_op } = Lib;
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
@@ -356,6 +357,20 @@ export class Ext extends Ecs.System<ExtEvent> {
             _toggle_workspace_number_indicator(this.settings.workspace_number_indicator());
         });
         this._settings_signal_ids.push([this.settings.ext, id_ws_num]);
+
+        const id_hide_panel = this.settings.ext.connect('changed::hide-panel-icon', () => {
+            if (indicator) {
+                const sessionMode = (Main as any).sessionMode;
+                const isLocked = sessionMode ? sessionMode.isLocked : false;
+                indicator.button.visible = !isLocked && !this.settings.hide_panel_icon();
+            }
+        });
+        this._settings_signal_ids.push([this.settings.ext, id_hide_panel]);
+
+        const id_qs_toggle = this.settings.ext.connect('changed::quick-settings-toggle', () => {
+            _toggle_quick_settings_indicator(this.settings.quick_settings_toggle());
+        });
+        this._settings_signal_ids.push([this.settings.ext, id_qs_toggle]);
 
         // Workspace animation style — static wallpaper + window swing
         const id_ws_anim = this.settings.ext.connect('changed::workspace-animation-style', () => {
@@ -1045,7 +1060,7 @@ export class Ext extends Ecs.System<ExtEvent> {
         if (sessionMode) {
             this._unlock_signal_id = sessionMode.connect('updated', () => {
                 if (indicator) {
-                    indicator.button.visible = !sessionMode.isLocked;
+                    indicator.button.visible = !sessionMode.isLocked && !this.settings.hide_panel_icon();
                 }
 
                 if (sessionMode.isLocked) {
@@ -3685,10 +3700,12 @@ export default class OTilingExtension extends Extension {
         if (!indicator && currentPanel) {
             indicator = new PanelSettings.Indicator(ext);
             currentPanel.addToStatusArea('o-tiling', indicator.button);
+            indicator.button.visible = !ext.settings.hide_panel_icon();
         }
 
         // Workspace-number indicator in panel
         _toggle_workspace_number_indicator(ext.settings.workspace_number_indicator());
+        _toggle_quick_settings_indicator(ext.settings.quick_settings_toggle());
 
         ext.keybindings.enable(ext.keybindings.global).enable(ext.keybindings.window_focus);
 
@@ -3722,6 +3739,11 @@ export default class OTilingExtension extends Extension {
             workspace_number_indicator = null;
         }
 
+        if (quick_settings_indicator) {
+            quick_settings_indicator.destroy();
+            quick_settings_indicator = null;
+        }
+
         enable_window_attention_handler();
         Window.cleanup_main_loop_sources();
         scheduler.destroy();
@@ -3742,6 +3764,19 @@ function disable_window_attention_handler() {
     if (handler && handler._windowDemandsAttentionId) {
         (global as any).display.disconnect(handler._windowDemandsAttentionId);
         handler._windowDemandsAttentionId = null;
+    }
+}
+
+function _toggle_quick_settings_indicator(enable: boolean): void {
+    const quickSettings = (Main as any).panel?.statusArea?.quickSettings;
+    if (!quickSettings) return;
+
+    if (enable && !quick_settings_indicator) {
+        quick_settings_indicator = new (PanelSettings.QuickSettingsIndicator as any)(ext);
+        quickSettings.addExternalIndicator(quick_settings_indicator);
+    } else if (!enable && quick_settings_indicator) {
+        quick_settings_indicator.destroy();
+        quick_settings_indicator = null;
     }
 }
 

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -159,10 +159,10 @@ export default class OTilingPreferences extends ExtensionPreferences {
         const winAnimRow = new Adw.ComboRow({
             title: _('Window Animations'),
             subtitle: _('Open/close/move/resize animation style. "Hyprland" adds bouncy overshoot like Hyprland/niri.'),
-            model: Gtk.StringList.new(['Default (native GNOME)', 'Hyprland-style (bouncy)', 'None (instant)']),
+            model: Gtk.StringList.new(['Default (native GNOME)', 'Hyprland-style (bouncy)', 'Glide (smooth slide)']),
         });
         overviewGroup.add(winAnimRow);
-        const winAnimValues: string[] = ['default', 'hyprland', 'none'];
+        const winAnimValues: string[] = ['default', 'hyprland', 'glide'];
         winAnimRow.set_selected(Math.max(0, winAnimValues.indexOf(settings.get_string('window-animation-style'))));
         winAnimRow.connect('notify::selected', () => {
             settings.set_string('window-animation-style', winAnimValues[winAnimRow.selected] ?? 'default');

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -436,6 +436,24 @@ export default class OTilingPreferences extends ExtensionPreferences {
         behaviorGroup.add(stackingWithMouse);
         settings.bind('stacking-with-mouse', stackingWithMouse as any, 'active', Gio.SettingsBindFlags.DEFAULT);
 
+        const debugMode = new Adw.SwitchRow({
+            title: _('Debug Mode'),
+            subtitle: _('Enable detailed logging for debugging purposes'),
+        });
+        behaviorGroup.add(debugMode);
+        
+        debugMode.active = settings.get_uint('log-level') === 4;
+        debugMode.connect('notify::active', () => {
+            settings.set_uint('log-level', debugMode.active ? 4 : 0);
+        });
+        settings.connect('changed::log-level', () => {
+            const isDebug = settings.get_uint('log-level') === 4;
+            if (debugMode.active !== isDebug) {
+                debugMode.active = isDebug;
+            }
+        });
+
+
         // Gaps Group
         const gapsGroup = new Adw.PreferencesGroup({
             title: _('Gaps'),

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -156,6 +156,18 @@ export default class OTilingPreferences extends ExtensionPreferences {
             settings.set_string('workspace-animation-style', wsAnimValues[wsAnimRow.selected] ?? 'none');
         });
 
+        const winAnimRow = new Adw.ComboRow({
+            title: _('Window Animations'),
+            subtitle: _('Open/close/move/resize animation style. "Hyprland" adds bouncy overshoot like Hyprland/niri.'),
+            model: Gtk.StringList.new(['Default (native GNOME)', 'Hyprland-style (bouncy)', 'None (instant)']),
+        });
+        overviewGroup.add(winAnimRow);
+        const winAnimValues: string[] = ['default', 'hyprland', 'none'];
+        winAnimRow.set_selected(Math.max(0, winAnimValues.indexOf(settings.get_string('window-animation-style'))));
+        winAnimRow.connect('notify::selected', () => {
+            settings.set_string('window-animation-style', winAnimValues[winAnimRow.selected] ?? 'default');
+        });
+
         // Panel Transparency Group
         const panelGroup = new Adw.PreferencesGroup({
             title: _('Panel'),

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -142,6 +142,19 @@ export default class OTilingPreferences extends ExtensionPreferences {
         overviewGroup.add(wsNumberIndicatorRow);
         settings.bind('workspace-number-indicator', wsNumberIndicatorRow as any, 'active', Gio.SettingsBindFlags.DEFAULT);
 
+        // Workspace Animation Style
+        const wsAnimRow = new Adw.ComboRow({
+            title: _('Workspace Switch Animation'),
+            subtitle: _('Wallpaper stays fixed; only windows animate. "Swing" mimics Hyprland elastic slide.'),
+            model: Gtk.StringList.new(['None (default GNOME)', 'Slide', 'Swing (Hyprland-style)']),
+        });
+        overviewGroup.add(wsAnimRow);
+        // Map setting value to combo index: 0=none, 1=slide, 2=swing
+        const wsAnimValues: string[] = ['none', 'slide', 'swing'];
+        wsAnimRow.set_selected(Math.max(0, wsAnimValues.indexOf(settings.get_string('workspace-animation-style'))));
+        wsAnimRow.connect('notify::selected', () => {
+            settings.set_string('workspace-animation-style', wsAnimValues[wsAnimRow.selected] ?? 'none');
+        });
 
         // Panel Transparency Group
         const panelGroup = new Adw.PreferencesGroup({

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -1,6 +1,5 @@
 import Gtk from 'gi://Gtk';
 import Adw from 'gi://Adw';
-// Gdk dynamically imported
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
 import { ExtensionPreferences, gettext as _ } from 'resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js';
@@ -180,6 +179,20 @@ export default class OTilingPreferences extends ExtensionPreferences {
         });
         panelGroup.add(panelTransRow);
         settings.bind('panel-transparency', panelTransRow as any, 'active', Gio.SettingsBindFlags.DEFAULT);
+
+        const hidePanelIconRow = new Adw.SwitchRow({
+            title: _('Hide Panel Icon'),
+            subtitle: _('Hide the O-Tiling icon and menu from the top panel'),
+        });
+        panelGroup.add(hidePanelIconRow);
+        settings.bind('hide-panel-icon', hidePanelIconRow as any, 'active', Gio.SettingsBindFlags.DEFAULT);
+
+        const quickSettingsRow = new Adw.SwitchRow({
+            title: _('Show in Quick Settings'),
+            subtitle: _('Add an O-Tiling toggle to the Quick Settings menu instead of a dedicated panel icon'),
+        });
+        panelGroup.add(quickSettingsRow);
+        settings.bind('quick-settings-toggle', quickSettingsRow as any, 'active', Gio.SettingsBindFlags.DEFAULT);
 
         const panelOpacityRow = new Adw.SpinRow({
             title: _('Panel Opacity (%)'),

--- a/src/system/executor.ts
+++ b/src/system/executor.ts
@@ -1,5 +1,6 @@
 import * as Ecs from '../core/ecs.js';
 import * as utils from '../utils/utils.js';
+import * as Lib from '../utils/lib.js';
 import GLib from 'gi://GLib';
 import Meta from 'gi://Meta';
 
@@ -39,7 +40,7 @@ export class GLibExecutor<T> implements Executor<T> {
         // Prefer Meta.Later for Shell extensions to avoid IN_PAINT crashes
         if ((global as any).compositor?.get_laters()) {
             this.#used_laters = true;
-            this.#event_loop = utils.later_add(Meta.LaterType.BEFORE_REDRAW, action);
+            this.#event_loop = Lib.later_add(Meta.LaterType.BEFORE_REDRAW, action);
         } else {
             this.#used_laters = false;
             this.#event_loop = GLib.idle_add(GLib.PRIORITY_DEFAULT, action);
@@ -50,7 +51,7 @@ export class GLibExecutor<T> implements Executor<T> {
         if (this.#event_loop !== null) {
             // Use the matching removal fn: later_remove for laters, source_remove for idle.
             if (this.#used_laters) {
-                utils.later_remove(this.#event_loop);
+                Lib.later_remove(this.#event_loop);
             } else {
                 GLib.source_remove(this.#event_loop);
             }

--- a/src/system/executor.ts
+++ b/src/system/executor.ts
@@ -1,5 +1,5 @@
 import * as Ecs from '../core/ecs.js';
-import * as utils from '../utils/utils.js';
+
 import * as Lib from '../utils/lib.js';
 import GLib from 'gi://GLib';
 import Meta from 'gi://Meta';

--- a/src/system/executor.ts
+++ b/src/system/executor.ts
@@ -78,9 +78,6 @@ export class OnceExecutor<X, T extends Iterable<X>> {
 
             if (typeof next === 'undefined') {
                 if (then) {
-                    if (this.#signal !== null) {
-                        GLib.source_remove(this.#signal);
-                    }
                     const id2 = GLib.timeout_add(GLib.PRIORITY_DEFAULT, delay, () => {
                         if (this.#signal === id2) {
                             this.#signal = null;

--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -88,6 +88,7 @@ const ACTIVE_HINT_OVERLAY_COLOR_RGBA = 'active-hint-overlay-color-rgba';
 const ACTIVE_HINT_OVERLAY_ALL_WINDOWS = 'active-hint-overlay-all-windows';
 const WORKSPACE_SWITCHER_STYLE = 'workspace-switcher-style';
 const WORKSPACE_NUMBER_INDICATOR = 'workspace-number-indicator';
+const WORKSPACE_ANIMATION_STYLE = 'workspace-animation-style';
 
 const THEME_CONSISTENCY_STYLE = 'theme-consistency-style';
 const SKIP_OVERVIEW = 'skip-overview';
@@ -280,6 +281,10 @@ export class ExtensionSettings {
         return this.ext.get_boolean(WORKSPACE_NUMBER_INDICATOR);
     }
 
+    workspace_animation_style(): string {
+        return this.ext.get_string(WORKSPACE_ANIMATION_STYLE) ?? 'none';
+    }
+
 
 
 
@@ -440,6 +445,10 @@ export class ExtensionSettings {
 
     set_workspace_number_indicator(set: boolean) {
         this.ext.set_boolean(WORKSPACE_NUMBER_INDICATOR, set);
+    }
+
+    set_workspace_animation_style(style: string) {
+        this.ext.set_string(WORKSPACE_ANIMATION_STYLE, style);
     }
 
 

--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -89,6 +89,8 @@ const ACTIVE_HINT_OVERLAY_ALL_WINDOWS = 'active-hint-overlay-all-windows';
 const WORKSPACE_SWITCHER_STYLE = 'workspace-switcher-style';
 const WORKSPACE_NUMBER_INDICATOR = 'workspace-number-indicator';
 const WORKSPACE_ANIMATION_STYLE = 'workspace-animation-style';
+const WINDOW_ANIMATION_STYLE = 'window-animation-style';
+const WINDOW_ANIMATION_DURATION = 'window-animation-duration';
 
 const THEME_CONSISTENCY_STYLE = 'theme-consistency-style';
 const SKIP_OVERVIEW = 'skip-overview';
@@ -285,6 +287,14 @@ export class ExtensionSettings {
         return this.ext.get_string(WORKSPACE_ANIMATION_STYLE) ?? 'none';
     }
 
+    window_animation_style(): string {
+        return this.ext.get_string(WINDOW_ANIMATION_STYLE) ?? 'default';
+    }
+
+    window_animation_duration(): number {
+        return this.ext.get_int(WINDOW_ANIMATION_DURATION);
+    }
+
 
 
 
@@ -449,6 +459,14 @@ export class ExtensionSettings {
 
     set_workspace_animation_style(style: string) {
         this.ext.set_string(WORKSPACE_ANIMATION_STYLE, style);
+    }
+
+    set_window_animation_style(style: string) {
+        this.ext.set_string(WINDOW_ANIMATION_STYLE, style);
+    }
+
+    set_window_animation_duration(ms: number) {
+        this.ext.set_int(WINDOW_ANIMATION_DURATION, ms);
     }
 
 

--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -88,6 +88,8 @@ const ACTIVE_HINT_OVERLAY_COLOR_RGBA = 'active-hint-overlay-color-rgba';
 const ACTIVE_HINT_OVERLAY_ALL_WINDOWS = 'active-hint-overlay-all-windows';
 const WORKSPACE_SWITCHER_STYLE = 'workspace-switcher-style';
 const WORKSPACE_NUMBER_INDICATOR = 'workspace-number-indicator';
+const HIDE_PANEL_ICON = 'hide-panel-icon';
+const QUICK_SETTINGS_TOGGLE = 'quick-settings-toggle';
 const WORKSPACE_ANIMATION_STYLE = 'workspace-animation-style';
 const WINDOW_ANIMATION_STYLE = 'window-animation-style';
 const WINDOW_ANIMATION_DURATION = 'window-animation-duration';
@@ -283,6 +285,14 @@ export class ExtensionSettings {
         return this.ext.get_boolean(WORKSPACE_NUMBER_INDICATOR);
     }
 
+    hide_panel_icon(): boolean {
+        return this.ext.get_boolean(HIDE_PANEL_ICON);
+    }
+
+    quick_settings_toggle(): boolean {
+        return this.ext.get_boolean(QUICK_SETTINGS_TOGGLE);
+    }
+
     workspace_animation_style(): string {
         return this.ext.get_string(WORKSPACE_ANIMATION_STYLE) ?? 'none';
     }
@@ -455,6 +465,14 @@ export class ExtensionSettings {
 
     set_workspace_number_indicator(set: boolean) {
         this.ext.set_boolean(WORKSPACE_NUMBER_INDICATOR, set);
+    }
+
+    set_hide_panel_icon(set: boolean) {
+        this.ext.set_boolean(HIDE_PANEL_ICON, set);
+    }
+
+    set_quick_settings_toggle(set: boolean) {
+        this.ext.set_boolean(QUICK_SETTINGS_TOGGLE, set);
     }
 
     set_workspace_animation_style(style: string) {

--- a/src/ui/panel_settings.ts
+++ b/src/ui/panel_settings.ts
@@ -523,13 +523,11 @@ export class WorkspaceNumberIndicator {
         this.button.add_child(this._box);
 
         // Overview toggle button — same pill style as workspace number buttons
-        const _ovIconPath = `${get_current_path()}/icons/o-tiling-ws-overview-symbolic.svg`;
-        const _ovGicon = Gio.icon_new_for_string(_ovIconPath);
         this._ovBtn = new St.Button({
             style_class: 'o-tiling-ws-overview-btn',
-            child: new St.Icon({
-                gicon: _ovGicon,
-                icon_size: 12,
+            child: new St.Label({
+                text: '...',
+                y_align: Clutter.ActorAlign.CENTER,
             }),
             y_align: Clutter.ActorAlign.CENTER,
         });

--- a/src/ui/panel_settings.ts
+++ b/src/ui/panel_settings.ts
@@ -16,6 +16,7 @@ import {
     PopupSeparatorMenuItem,
 } from 'resource:///org/gnome/shell/ui/popupMenu.js';
 import { Button } from 'resource:///org/gnome/shell/ui/panelMenu.js';
+import { QuickMenuToggle, SystemIndicator } from 'resource:///org/gnome/shell/ui/quickSettings.js';
 import GObject from 'gi://GObject';
 import GLib from 'gi://GLib';
 
@@ -596,3 +597,63 @@ export class WorkspaceNumberIndicator {
         this.button.destroy();
     }
 }
+
+export const QuickSettingsToggle = GObject.registerClass(
+class QuickSettingsToggle extends QuickMenuToggle {
+    constructor(ext: Ext) {
+        super({ title: _('O-Tiling'), iconName: 'view-grid-symbolic', toggleMode: true });
+        this.checked = !ext._ext_soft_disabled;
+
+        this.connect('clicked', () => {
+            if (this.checked) {
+                ext.ext_soft_enable();
+            } else {
+                ext.ext_soft_disable();
+            }
+        });
+
+        this.menu.setHeader('view-grid-symbolic', _('O-Tiling'), _('Tiling Window Management'));
+        this.menu.addMenuItem(workspace_tiled(ext));
+        this.menu.addMenuItem(lock_master_window(ext));
+        this.menu.addMenuItem(new PopupSeparatorMenuItem());
+        this.menu.addMenuItem(toggle(
+            _('Active Hint'),
+            ext.settings.active_hint(),
+            'focus-windows-symbolic',
+            (state) => ext.settings.set_active_hint(state),
+        ));
+        this.menu.addMenuItem(new PopupSeparatorMenuItem());
+        this.menu.addMenuItem(settings_button(this.menu));
+    }
+});
+
+export const QuickSettingsIndicator = GObject.registerClass(
+class QuickSettingsIndicator extends SystemIndicator {
+    quickSettingsItems: any[];
+
+    constructor(ext: Ext) {
+        super();
+        const indicatorIcon = this._addIndicator();
+        indicatorIcon.icon_name = 'view-grid-symbolic';
+        indicatorIcon.visible = !ext._ext_soft_disabled;
+
+        this.quickSettingsItems = [];
+        const toggleItem = new QuickSettingsToggle(ext);
+        this.quickSettingsItems.push(toggleItem);
+
+        toggleItem.bind_property(
+            'checked',
+            indicatorIcon,
+            'visible',
+            GObject.BindingFlags.SYNC_CREATE
+        );
+    }
+
+    destroy() {
+        for (const item of this.quickSettingsItems) {
+            item.destroy();
+        }
+        this.quickSettingsItems = [];
+        super.destroy();
+    }
+});

--- a/src/ui/panel_settings.ts
+++ b/src/ui/panel_settings.ts
@@ -159,7 +159,7 @@ export class Indicator {
 
     update_workspace_tiling_state() {
         const ext = this.ext;
-        if (!this.button || !this.button.visible || !this.button.get_stage?.()) {
+        if (!this.button || !this.button.visible || !this.button.get_stage()) {
             return;
         }
         if (ext && this.toggle_workspace_tiled) {

--- a/src/ui/panel_settings.ts
+++ b/src/ui/panel_settings.ts
@@ -40,7 +40,6 @@ export class Indicator {
     border_radius: any;
 
     entry_gaps: any;
-    signals: Array<[any, number]> = [];
 
     constructor(ext: Ext) {
         this.ext = ext;
@@ -207,10 +206,6 @@ export class Indicator {
     }
 
     destroy() {
-        for (const [obj, id] of this.signals) {
-            obj.disconnect(id);
-        }
-        this.signals = [];
         this.button.destroy();
     }
 }

--- a/src/ui/panel_settings.ts
+++ b/src/ui/panel_settings.ts
@@ -37,7 +37,6 @@ export class Indicator {
 
 
     toggle_active: any;
-    toggle_debug: any;
     border_radius: any;
 
     entry_gaps: any;
@@ -151,15 +150,6 @@ export class Indicator {
         bm.addMenuItem(settings_button(bm));
         bm.addMenuItem(floating_window_exceptions(ext, bm));
 
-        // ── Debug Mode ──────────────────────────────────────────
-        this.toggle_debug = toggle(
-            _('Debug Mode'),
-            ext.settings.log_level() === 4,
-            'utilities-terminal-symbolic',
-            (state) => ext.settings.set_log_level(state ? 4 : 0),
-        );
-        bm.addMenuItem(this.toggle_debug);
-
         bm.addMenuItem(new PopupSeparatorMenuItem());
 
         this.toggle_tiled = tiled(ext);
@@ -207,11 +197,6 @@ export class Indicator {
                     this.presets_item.setSensitive(false);
                 }
             }
-
-            if (this.toggle_debug) {
-                this.toggle_debug.setToggleState(ext.settings.log_level() === 4);
-            }
-
             // Update panel icon to reflect current workspace tiling state
             if (ext.auto_tiler && tiled) {
                 this.button.icon.gicon = ext.button_gio_icon_auto_on;

--- a/src/ui/panel_settings.ts
+++ b/src/ui/panel_settings.ts
@@ -166,7 +166,9 @@ export class Indicator {
             const workspace = ext.active_workspace();
             const monitor = ext.active_monitor();
             const tiled = ext.is_workspace_tiled(workspace);
+            ext._indicator_updating = true;
             this.toggle_workspace_tiled.setToggleState(tiled);
+            ext._indicator_updating = false;
             if (this.toggle_workspace_tiled.updateIcon) {
                 this.toggle_workspace_tiled.updateIcon(tiled);
             }
@@ -395,6 +397,8 @@ function workspace_tiled(ext: Ext): any {
         ext.is_workspace_tiled(ext.active_workspace()),
         { on: 'view-grid-symbolic', off: 'view-list-symbolic' },
         (shouldTile) => {
+            if (ext._indicator_updating)
+                return;
             ext.workspace_tiling_set(ext.active_workspace(), shouldTile);
         }
     );

--- a/src/ui/theme_consistency/apply.ts
+++ b/src/ui/theme_consistency/apply.ts
@@ -1,62 +1,34 @@
 import GLib from 'gi://GLib';
-import Gio from 'gi://Gio';
 import * as log from '../../utils/log.js';
+import * as utils from '../../utils/utils.js';
+import * as result from '../../utils/result.js';
 import { getGtkCss } from './gtk.js';
 
 const O_TILING_START = '/* === O-TILING START === */';
 const O_TILING_END   = '/* === O-TILING END === */';
 
-function readFileAsync(path: string): Promise<string> {
-    return new Promise((resolve, reject) => {
-        const file = Gio.File.new_for_path(path);
-        file.load_contents_async(null, (obj, res) => {
-            try {
-                const [, bytes] = (obj as Gio.File).load_contents_finish(res);
-                resolve(new TextDecoder().decode(bytes));
-            } catch (e) {
-                reject(e);
-            }
-        });
-    });
-}
-
-function writeFileAsync(path: string, contents: string): Promise<void> {
-    return new Promise((resolve, reject) => {
-        const file = Gio.File.new_for_path(path);
-        const bytes = new TextEncoder().encode(contents);
-        file.replace_contents_async(
-            bytes, null, false, Gio.FileCreateFlags.NONE, null,
-            (obj, res) => {
-                try {
-                    (obj as Gio.File).replace_contents_finish(res);
-                    resolve();
-                } catch (e) {
-                    reject(e);
-                }
-            }
-        );
-    });
-}
-
 /** Removes the O-Tiling block from a gtk.css file (leaves the rest intact). */
 async function removeCssBlock(path: string): Promise<void> {
-    let content = '';
     if (!GLib.file_test(path, GLib.FileTest.EXISTS)) {
         return; // File doesn't exist — nothing to remove.
     }
-    try {
-        content = await readFileAsync(path);
-    } catch (e) {
-        log.warn(`Failed to read GTK CSS file at ${path}: ${e}`);
+
+    const read = await utils.read_to_string(path);
+    if (read.kind === result.ERR) {
+        log.warn(`Failed to read GTK CSS file at ${path}: ${read.value.format()}`);
         return;
     }
 
+    let content = read.value;
     const startIndex = content.indexOf(O_TILING_START);
     const endIndex   = content.indexOf(O_TILING_END);
 
     if (startIndex !== -1 && endIndex !== -1 && endIndex > startIndex) {
         content = content.slice(0, startIndex) + content.slice(endIndex + O_TILING_END.length);
-        await writeFileAsync(path, content.trim() + '\n');
+        const write = await utils.write_string(path, content.trim() + '\n');
+        if (write.kind === result.ERR) {
+            log.warn(`Failed to write GTK CSS file at ${path}: ${write.value.format()}`);
+        }
     }
 }
 
@@ -97,10 +69,11 @@ export async function applyThemeConsistency(style: 'rounded' | 'sharp' = 'rounde
         const updateCssFile = async (path: string, newCss: string) => {
             let content = '';
             if (GLib.file_test(path, GLib.FileTest.EXISTS)) {
-                try {
-                    content = await readFileAsync(path);
-                } catch (e) {
-                    log.warn(`Failed to read GTK CSS file for update at ${path}: ${e}`);
+                const read = await utils.read_to_string(path);
+                if (read.kind === result.ERR) {
+                    log.warn(`Failed to read GTK CSS file for update at ${path}: ${read.value.format()}`);
+                } else {
+                    content = read.value;
                 }
             }
 
@@ -112,7 +85,10 @@ export async function applyThemeConsistency(style: 'rounded' | 'sharp' = 'rounde
             }
 
             content = content.trim() + '\n\n' + O_TILING_START + '\n' + newCss + '\n' + O_TILING_END + '\n';
-            await writeFileAsync(path, content.trimStart());
+            const write = await utils.write_string(path, content.trimStart());
+            if (write.kind === result.ERR) {
+                log.warn(`Failed to write GTK CSS file at ${path}: ${write.value.format()}`);
+            }
         };
 
         await updateCssFile(`${gtk4Dir}/gtk.css`, gtkCss);

--- a/src/ui/window_animation.ts
+++ b/src/ui/window_animation.ts
@@ -2,16 +2,13 @@ import Clutter from 'gi://Clutter';
 import Meta from 'gi://Meta';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
-export type WindowAnimationStyle = 'default' | 'hyprland' | 'none';
+export type WindowAnimationStyle = 'default' | 'hyprland' | 'glide';
 
 export class WindowAnimationManager {
     private _style: WindowAnimationStyle;
     private _duration: number;
     private _enabled = false;
-
-    private _origMapWindow = (Main.wm as any)._mapWindow;
-    private _origDestroyWindow = (Main.wm as any)._destroyWindow;
-    private _origSizeChangedWindow = (Main.wm as any)._sizeChangedWindow;
+    private _origShouldAnimateActor: Function | null = null;
 
     constructor(style: WindowAnimationStyle = 'default', duration: number = 200) {
         this._style = style;
@@ -21,23 +18,25 @@ export class WindowAnimationManager {
     enable(): void {
         if (this._enabled) return;
         this._enabled = true;
-        if (this._style === 'hyprland') this._patchHyprland();
+        this._patchShouldAnimateActor();
     }
 
     disable(): void {
         if (!this._enabled) return;
         this._enabled = false;
-        (Main.wm as any)._mapWindow = this._origMapWindow;
-        (Main.wm as any)._destroyWindow = this._origDestroyWindow;
-        (Main.wm as any)._sizeChangedWindow = this._origSizeChangedWindow;
+        if (this._origShouldAnimateActor) {
+            (Main.wm as any)._shouldAnimateActor = this._origShouldAnimateActor;
+            this._origShouldAnimateActor = null;
+        }
     }
 
     setStyle(style: WindowAnimationStyle): void {
         if (style === this._style) return;
-        const was_enabled = this._enabled;
-        if (was_enabled) this.disable();
         this._style = style;
-        if (was_enabled) this.enable();
+    }
+
+    setDuration(duration: number): void {
+        this._duration = duration;
     }
 
     get style(): WindowAnimationStyle {
@@ -46,11 +45,6 @@ export class WindowAnimationManager {
 
     applyMove(actor: Clutter.Actor, x: number, y: number, width: number, height: number, commit: () => void): void {
         actor.remove_all_transitions();
-
-        if (this._style === 'none') {
-            commit();
-            return;
-        }
 
         const same_size = actor.width === width && actor.height === height;
         if (!same_size) {
@@ -70,91 +64,58 @@ export class WindowAnimationManager {
         });
     }
 
-    private _patchHyprland(): void {
-        const duration = this._duration;
+    private _patchShouldAnimateActor(): void {
+        const orig = (Main.wm as any)._shouldAnimateActor;
+        this._origShouldAnimateActor = orig;
 
-        (Main.wm as any)._mapWindow = function (this: any, shellwm: any, actor: any) {
-            const types = [Meta.WindowType.NORMAL, Meta.WindowType.MODAL_DIALOG, Meta.WindowType.DIALOG];
-            if (!this._shouldAnimateActor(actor, types)) {
-                shellwm.completed_map_animation(actor);
-                return;
+        const manager = this;
+
+        (Main.wm as any)._shouldAnimateActor = function (actor: Clutter.Actor, types: Meta.WindowType[]) {
+            const should_animate = orig.call(this, actor, types);
+            if (!should_animate) return false;
+
+            if (manager._style === 'default') return true;
+
+            const stack = (new Error()).stack || '';
+            const forClosing = stack.includes('_destroyWindow@');
+            const forOpening = stack.includes('_mapWindow@');
+
+            if (forClosing || forOpening) {
+                const orig_ease = (actor as any).ease;
+
+                (actor as any).ease = function (params: any) {
+                    (actor as any).ease = orig_ease;
+
+                    if (manager._style === 'glide') {
+                        if (forOpening) {
+                            actor.set_scale(1, 1);
+                            actor.translation_y = 30; // start slightly below
+                            params.duration = manager._duration;
+                            params.mode = Clutter.AnimationMode.EASE_OUT_QUART;
+                            params.translation_y = 0;
+                        } else {
+                            params.duration = Math.round(manager._duration * 0.8);
+                            params.mode = Clutter.AnimationMode.EASE_IN_QUART;
+                            params.translation_y = 30; // exit sliding down
+                        }
+                    } else if (manager._style === 'hyprland') {
+                        if (forOpening) {
+                            actor.set_scale(0.85, 0.85);
+                            params.duration = manager._duration;
+                            params.mode = Clutter.AnimationMode.EASE_OUT_BACK;
+                        } else {
+                            params.duration = Math.round(manager._duration * 0.8);
+                            params.mode = Clutter.AnimationMode.EASE_IN_CUBIC;
+                            params.scale_x = 0.85;
+                            params.scale_y = 0.85;
+                        }
+                    }
+
+                    orig_ease.call(actor, params);
+                };
             }
 
-            actor.set_scale(0.85, 0.85);
-            actor.set_opacity(0);
-            actor.show();
-
-            actor.ease({
-                opacity: 255,
-                scale_x: 1,
-                scale_y: 1,
-                duration,
-                mode: Clutter.AnimationMode.EASE_OUT_BACK,
-                onStopped: () => shellwm.completed_map_animation(actor),
-            });
-        };
-
-        (Main.wm as any)._destroyWindow = function (this: any, shellwm: any, actor: any) {
-            const types = [Meta.WindowType.NORMAL, Meta.WindowType.MODAL_DIALOG, Meta.WindowType.DIALOG];
-            if (!this._shouldAnimateActor(actor, types)) {
-                shellwm.completed_destroy(actor);
-                return;
-            }
-
-            actor.set_pivot_point(0.5, 0.5);
-            actor.ease({
-                opacity: 0,
-                scale_x: 0.85,
-                scale_y: 0.85,
-                duration: Math.round(duration * 0.8),
-                mode: Clutter.AnimationMode.EASE_IN_CUBIC,
-                onStopped: () => shellwm.completed_destroy(actor),
-            });
-        };
-
-        (Main.wm as any)._sizeChangedWindow = function (this: any, shellwm: any, actor: any) {
-            if (!actor.__animationInfo) return;
-            if (this._resizing.has(actor)) return;
-
-            const target_rect = actor.meta_window.get_frame_rect();
-            const source_rect = actor.__animationInfo.oldRect;
-            const actor_clone = actor.__animationInfo.clone;
-
-            const scale_x = target_rect.width / source_rect.width;
-            const scale_y = target_rect.height / source_rect.height;
-
-            this._resizePending.delete(actor);
-            this._resizing.add(actor);
-
-            Main.uiGroup.add_child(actor_clone);
-            actor_clone.ease({
-                x: target_rect.x,
-                y: target_rect.y,
-                scale_x,
-                scale_y,
-                opacity: 0,
-                duration,
-                mode: Clutter.AnimationMode.EASE_OUT_BACK,
-            });
-
-            actor.translation_x = -target_rect.x + source_rect.x;
-            actor.translation_y = -target_rect.y + source_rect.y;
-            actor.scale_x = 1 / scale_x;
-            actor.scale_y = 1 / scale_y;
-
-            actor.ease({
-                scale_x: 1,
-                scale_y: 1,
-                translation_x: 0,
-                translation_y: 0,
-                duration,
-                mode: Clutter.AnimationMode.EASE_OUT_BACK,
-                onStopped: () => this._sizeChangeWindowDone(shellwm, actor),
-            });
-
-            if (!actor.__animationInfo) return;
-            actor.thaw();
-            actor.__animationInfo.frozen = false;
+            return true;
         };
     }
 }

--- a/src/ui/window_animation.ts
+++ b/src/ui/window_animation.ts
@@ -4,11 +4,15 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 
 export type WindowAnimationStyle = 'default' | 'hyprland' | 'glide';
 
+const SHOW_WINDOW_ANIMATION_TIME = 150;
+const DESTROY_WINDOW_ANIMATION_TIME = 100;
+
 export class WindowAnimationManager {
     private _style: WindowAnimationStyle;
     private _duration: number;
     private _enabled = false;
-    private _origShouldAnimateActor: Function | null = null;
+    private _origMapWindow: Function | null = null;
+    private _origDestroyWindow: Function | null = null;
 
     constructor(style: WindowAnimationStyle = 'default', duration: number = 200) {
         this._style = style;
@@ -18,20 +22,117 @@ export class WindowAnimationManager {
     enable(): void {
         if (this._enabled) return;
         this._enabled = true;
-        this._patchShouldAnimateActor();
+
+        const wm = Main.wm as any;
+        this._origMapWindow = wm._mapWindow;
+        this._origDestroyWindow = wm._destroyWindow;
+
+        const manager = this;
+
+        wm._mapWindow = async function (shellwm: any, actor: any) {
+            if (manager._style === 'default')
+                return manager._origMapWindow!.call(this, shellwm, actor);
+
+            actor._windowType = actor.meta_window.get_window_type();
+            actor.meta_window.connectObject('notify::window-type', () => {
+                const type = actor.meta_window.get_window_type();
+                if (type === actor._windowType) return;
+                if (type === Meta.WindowType.MODAL_DIALOG ||
+                    actor._windowType === Meta.WindowType.MODAL_DIALOG) {
+                    const parent = actor.get_meta_window().get_transient_for();
+                    if (parent) (wm as any)._checkDimming(parent);
+                }
+                actor._windowType = type;
+            }, actor);
+            actor.meta_window.connect('unmanaged', (window: any) => {
+                const parent = window.get_transient_for();
+                if (parent) (wm as any)._checkDimming(parent);
+            });
+
+            if (actor.meta_window.is_attached_dialog())
+                (wm as any)._checkDimming(actor.get_meta_window().get_transient_for());
+
+            const types = [
+                Meta.WindowType.NORMAL,
+                Meta.WindowType.DIALOG,
+                Meta.WindowType.MODAL_DIALOG,
+            ];
+            if (!(wm as any)._shouldAnimateActor(actor, types)) {
+                shellwm.completed_map(actor);
+                return;
+            }
+
+            const animType = (wm as any)._getAnimationWindowType(actor);
+            if (animType !== Meta.WindowType.NORMAL) {
+                return manager._origMapWindow!.call(this, shellwm, actor);
+            }
+
+            const { duration, mode, initProps } = manager._getMapParams();
+            actor.set_pivot_point(0.5, 0.5);
+            Object.assign(actor, initProps);
+            actor.show();
+            (wm as any)._mapping.add(actor);
+
+            actor.ease({
+                opacity: 255,
+                scale_x: 1,
+                scale_y: 1,
+                translation_y: 0,
+                duration,
+                mode,
+                onStopped: () => (wm as any)._mapWindowDone(shellwm, actor),
+            });
+        };
+
+        wm._destroyWindow = function (shellwm: any, actor: any) {
+            if (manager._style === 'default')
+                return manager._origDestroyWindow!.call(this, shellwm, actor);
+
+            const window = actor.meta_window;
+            window.disconnectObject(actor);
+
+            if (window.is_attached_dialog())
+                (wm as any)._checkDimming(window.get_transient_for());
+
+            const types = [
+                Meta.WindowType.NORMAL,
+                Meta.WindowType.DIALOG,
+                Meta.WindowType.MODAL_DIALOG,
+            ];
+            if (!(wm as any)._shouldAnimateActor(actor, types)) {
+                shellwm.completed_destroy(actor);
+                return;
+            }
+
+            const animType = (wm as any)._getAnimationWindowType(actor);
+            if (animType !== Meta.WindowType.NORMAL) {
+                return manager._origDestroyWindow!.call(this, shellwm, actor);
+            }
+
+            const { duration, mode, targetProps } = manager._getDestroyParams();
+            actor.set_pivot_point(0.5, 0.5);
+            (wm as any)._destroying.add(actor);
+
+            actor.ease({
+                ...targetProps,
+                duration,
+                mode,
+                onStopped: () => (wm as any)._destroyWindowDone(shellwm, actor),
+            });
+        };
     }
 
     disable(): void {
         if (!this._enabled) return;
         this._enabled = false;
-        if (this._origShouldAnimateActor) {
-            (Main.wm as any)._shouldAnimateActor = this._origShouldAnimateActor;
-            this._origShouldAnimateActor = null;
-        }
+        const wm = Main.wm as any;
+        wm._mapWindow = this._origMapWindow;
+        wm._destroyWindow = this._origDestroyWindow;
+        this._origMapWindow = null;
+        this._origDestroyWindow = null;
     }
 
     setStyle(style: WindowAnimationStyle): void {
-        if (style === this._style) return;
         this._style = style;
     }
 
@@ -46,13 +147,15 @@ export class WindowAnimationManager {
     applyMove(actor: Clutter.Actor, x: number, y: number, width: number, height: number, commit: () => void): void {
         actor.remove_all_transitions();
 
-        const same_size = actor.width === width && actor.height === height;
-        if (!same_size) {
+        if (actor.width !== width || actor.height !== height) {
             commit();
             return;
         }
 
-        const mode = this._style === 'hyprland' ? Clutter.AnimationMode.EASE_OUT_EXPO : Clutter.AnimationMode.EASE_OUT_CUBIC;
+        const mode = this._style === 'hyprland'
+            ? Clutter.AnimationMode.EASE_OUT_EXPO
+            : Clutter.AnimationMode.EASE_OUT_CUBIC;
+
         commit();
         actor.translation_x = actor.x - x;
         actor.translation_y = actor.y - y;
@@ -64,58 +167,37 @@ export class WindowAnimationManager {
         });
     }
 
-    private _patchShouldAnimateActor(): void {
-        const orig = (Main.wm as any)._shouldAnimateActor;
-        this._origShouldAnimateActor = orig;
+    private _getMapParams() {
+        if (this._style === 'glide') {
+            return {
+                duration: this._duration,
+                mode: Clutter.AnimationMode.EASE_OUT_QUART,
+                initProps: { opacity: 0, scale_x: 1, scale_y: 1, translation_y: 30 },
+            };
+        }
 
-        const manager = this;
+        // hyprland
+        return {
+            duration: this._duration,
+            mode: Clutter.AnimationMode.EASE_OUT_BACK,
+            initProps: { opacity: 0, scale_x: 0.85, scale_y: 0.85, translation_y: 0 },
+        };
+    }
 
-        (Main.wm as any)._shouldAnimateActor = function (actor: Clutter.Actor, types: Meta.WindowType[]) {
-            const should_animate = orig.call(this, actor, types);
-            if (!should_animate) return false;
+    private _getDestroyParams() {
+        if (this._style === 'glide') {
+            return {
+                duration: Math.round(this._duration * 0.8),
+                mode: Clutter.AnimationMode.EASE_IN_QUART,
+                targetProps: { opacity: 0, translation_y: 30 },
+            };
+        }
 
-            if (manager._style === 'default') return true;
-
-            const stack = (new Error()).stack || '';
-            const forClosing = stack.includes('_destroyWindow@');
-            const forOpening = stack.includes('_mapWindow@');
-
-            if (forClosing || forOpening) {
-                const orig_ease = (actor as any).ease;
-
-                (actor as any).ease = function (params: any) {
-                    (actor as any).ease = orig_ease;
-
-                    if (manager._style === 'glide') {
-                        if (forOpening) {
-                            actor.set_scale(1, 1);
-                            actor.translation_y = 30; // start slightly below
-                            params.duration = manager._duration;
-                            params.mode = Clutter.AnimationMode.EASE_OUT_QUART;
-                            params.translation_y = 0;
-                        } else {
-                            params.duration = Math.round(manager._duration * 0.8);
-                            params.mode = Clutter.AnimationMode.EASE_IN_QUART;
-                            params.translation_y = 30; // exit sliding down
-                        }
-                    } else if (manager._style === 'hyprland') {
-                        if (forOpening) {
-                            actor.set_scale(0.85, 0.85);
-                            params.duration = manager._duration;
-                            params.mode = Clutter.AnimationMode.EASE_OUT_BACK;
-                        } else {
-                            params.duration = Math.round(manager._duration * 0.8);
-                            params.mode = Clutter.AnimationMode.EASE_IN_CUBIC;
-                            params.scale_x = 0.85;
-                            params.scale_y = 0.85;
-                        }
-                    }
-
-                    orig_ease.call(actor, params);
-                };
-            }
-
-            return true;
+        // hyprland
+        return {
+            duration: Math.round(this._duration * 0.8),
+            mode: Clutter.AnimationMode.EASE_IN_CUBIC,
+            targetProps: { opacity: 0, scale_x: 0.85, scale_y: 0.85 },
         };
     }
 }

--- a/src/ui/window_animation.ts
+++ b/src/ui/window_animation.ts
@@ -1,0 +1,160 @@
+import Clutter from 'gi://Clutter';
+import Meta from 'gi://Meta';
+import * as Main from 'resource:///org/gnome/shell/ui/main.js';
+
+export type WindowAnimationStyle = 'default' | 'hyprland' | 'none';
+
+export class WindowAnimationManager {
+    private _style: WindowAnimationStyle;
+    private _duration: number;
+    private _enabled = false;
+
+    private _origMapWindow = (Main.wm as any)._mapWindow;
+    private _origDestroyWindow = (Main.wm as any)._destroyWindow;
+    private _origSizeChangedWindow = (Main.wm as any)._sizeChangedWindow;
+
+    constructor(style: WindowAnimationStyle = 'default', duration: number = 200) {
+        this._style = style;
+        this._duration = duration;
+    }
+
+    enable(): void {
+        if (this._enabled) return;
+        this._enabled = true;
+        if (this._style === 'hyprland') this._patchHyprland();
+    }
+
+    disable(): void {
+        if (!this._enabled) return;
+        this._enabled = false;
+        (Main.wm as any)._mapWindow = this._origMapWindow;
+        (Main.wm as any)._destroyWindow = this._origDestroyWindow;
+        (Main.wm as any)._sizeChangedWindow = this._origSizeChangedWindow;
+    }
+
+    setStyle(style: WindowAnimationStyle): void {
+        if (style === this._style) return;
+        const was_enabled = this._enabled;
+        if (was_enabled) this.disable();
+        this._style = style;
+        if (was_enabled) this.enable();
+    }
+
+    get style(): WindowAnimationStyle {
+        return this._style;
+    }
+
+    applyMove(actor: Clutter.Actor, x: number, y: number, width: number, height: number, commit: () => void): void {
+        actor.remove_all_transitions();
+
+        if (this._style === 'none') {
+            commit();
+            return;
+        }
+
+        const same_size = actor.width === width && actor.height === height;
+        if (!same_size) {
+            commit();
+            return;
+        }
+
+        const mode = this._style === 'hyprland' ? Clutter.AnimationMode.EASE_OUT_EXPO : Clutter.AnimationMode.EASE_OUT_CUBIC;
+        commit();
+        actor.translation_x = actor.x - x;
+        actor.translation_y = actor.y - y;
+        (actor as any).ease({
+            translation_x: 0,
+            translation_y: 0,
+            duration: this._duration,
+            mode,
+        });
+    }
+
+    private _patchHyprland(): void {
+        const duration = this._duration;
+
+        (Main.wm as any)._mapWindow = function (this: any, shellwm: any, actor: any) {
+            const types = [Meta.WindowType.NORMAL, Meta.WindowType.MODAL_DIALOG, Meta.WindowType.DIALOG];
+            if (!this._shouldAnimateActor(actor, types)) {
+                shellwm.completed_map_animation(actor);
+                return;
+            }
+
+            actor.set_scale(0.85, 0.85);
+            actor.set_opacity(0);
+            actor.show();
+
+            actor.ease({
+                opacity: 255,
+                scale_x: 1,
+                scale_y: 1,
+                duration,
+                mode: Clutter.AnimationMode.EASE_OUT_BACK,
+                onStopped: () => shellwm.completed_map_animation(actor),
+            });
+        };
+
+        (Main.wm as any)._destroyWindow = function (this: any, shellwm: any, actor: any) {
+            const types = [Meta.WindowType.NORMAL, Meta.WindowType.MODAL_DIALOG, Meta.WindowType.DIALOG];
+            if (!this._shouldAnimateActor(actor, types)) {
+                shellwm.completed_destroy(actor);
+                return;
+            }
+
+            actor.set_pivot_point(0.5, 0.5);
+            actor.ease({
+                opacity: 0,
+                scale_x: 0.85,
+                scale_y: 0.85,
+                duration: Math.round(duration * 0.8),
+                mode: Clutter.AnimationMode.EASE_IN_CUBIC,
+                onStopped: () => shellwm.completed_destroy(actor),
+            });
+        };
+
+        (Main.wm as any)._sizeChangedWindow = function (this: any, shellwm: any, actor: any) {
+            if (!actor.__animationInfo) return;
+            if (this._resizing.has(actor)) return;
+
+            const target_rect = actor.meta_window.get_frame_rect();
+            const source_rect = actor.__animationInfo.oldRect;
+            const actor_clone = actor.__animationInfo.clone;
+
+            const scale_x = target_rect.width / source_rect.width;
+            const scale_y = target_rect.height / source_rect.height;
+
+            this._resizePending.delete(actor);
+            this._resizing.add(actor);
+
+            Main.uiGroup.add_child(actor_clone);
+            actor_clone.ease({
+                x: target_rect.x,
+                y: target_rect.y,
+                scale_x,
+                scale_y,
+                opacity: 0,
+                duration,
+                mode: Clutter.AnimationMode.EASE_OUT_BACK,
+            });
+
+            actor.translation_x = -target_rect.x + source_rect.x;
+            actor.translation_y = -target_rect.y + source_rect.y;
+            actor.scale_x = 1 / scale_x;
+            actor.scale_y = 1 / scale_y;
+
+            actor.ease({
+                scale_x: 1,
+                scale_y: 1,
+                translation_x: 0,
+                translation_y: 0,
+                duration,
+                mode: Clutter.AnimationMode.EASE_OUT_BACK,
+                onStopped: () => this._sizeChangeWindowDone(shellwm, actor),
+            });
+
+            if (!actor.__animationInfo) return;
+            actor.thaw();
+            actor.__animationInfo.frozen = false;
+        };
+    }
+}

--- a/src/ui/workspace_animation.ts
+++ b/src/ui/workspace_animation.ts
@@ -26,6 +26,8 @@ export class WorkspaceAnimationManager {
 
         (WorkspaceAnimation as any).WorkspaceBackground.prototype._createBackground = function (this: any) { };
 
+        this._patchStaticBackground();
+
         if (this._style === 'swing') this._patchSwing();
     }
 
@@ -84,7 +86,9 @@ export class WorkspaceAnimationManager {
                 },
             });
         };
+    }
 
+    private _patchStaticBackground(): void {
         const origPrepare = this._origPrepareWorkspaceSwitch;
         (WorkspaceAnimation as any).WorkspaceAnimationController.prototype._prepareWorkspaceSwitch = function (
             this: any,

--- a/src/ui/workspace_animation.ts
+++ b/src/ui/workspace_animation.ts
@@ -1,5 +1,7 @@
 import Clutter from 'gi://Clutter';
+import Meta from 'gi://Meta';
 import * as WorkspaceAnimation from 'resource:///org/gnome/shell/ui/workspaceAnimation.js';
+import * as Background from 'resource:///org/gnome/shell/ui/background.js';
 
 export type AnimationStyle = 'slide' | 'swing' | 'none';
 
@@ -12,6 +14,7 @@ export class WorkspaceAnimationManager {
 
     private _origCreateBackground = (WorkspaceAnimation as any).WorkspaceBackground.prototype._createBackground;
     private _origEaseProperty = (WorkspaceAnimation as any).MonitorGroup.prototype.ease_property;
+    private _origPrepareWorkspaceSwitch = (WorkspaceAnimation as any).WorkspaceAnimationController.prototype._prepareWorkspaceSwitch;
 
     constructor(style: AnimationStyle = 'swing') {
         this._style = style;
@@ -32,6 +35,7 @@ export class WorkspaceAnimationManager {
 
         (WorkspaceAnimation as any).WorkspaceBackground.prototype._createBackground = this._origCreateBackground;
         (WorkspaceAnimation as any).MonitorGroup.prototype.ease_property = this._origEaseProperty;
+        (WorkspaceAnimation as any).WorkspaceAnimationController.prototype._prepareWorkspaceSwitch = this._origPrepareWorkspaceSwitch;
     }
 
     setStyle(style: AnimationStyle): void {
@@ -79,6 +83,36 @@ export class WorkspaceAnimationManager {
                     });
                 },
             });
+        };
+
+        const origPrepare = this._origPrepareWorkspaceSwitch;
+        (WorkspaceAnimation as any).WorkspaceAnimationController.prototype._prepareWorkspaceSwitch = function (
+            this: any,
+            ...args: any[]
+        ) {
+            origPrepare.apply(this, args);
+
+            for (const monitorGroup of this._switchData.monitors) {
+                if (monitorGroup._staticBackground) continue;
+
+                const bgGroup = new Meta.BackgroundGroup();
+                monitorGroup.insert_child_below(bgGroup, null);
+
+                monitorGroup._bgManager = new Background.BackgroundManager({
+                    container: bgGroup,
+                    monitorIndex: monitorGroup.index,
+                    controlPosition: false,
+                });
+
+                monitorGroup._staticBackground = bgGroup;
+
+                monitorGroup.connect('destroy', () => {
+                    if (monitorGroup._bgManager) {
+                        monitorGroup._bgManager.destroy();
+                        monitorGroup._bgManager = null;
+                    }
+                });
+            }
         };
     }
 }

--- a/src/ui/workspace_animation.ts
+++ b/src/ui/workspace_animation.ts
@@ -1,0 +1,84 @@
+import Clutter from 'gi://Clutter';
+import * as WorkspaceAnimation from 'resource:///org/gnome/shell/ui/workspaceAnimation.js';
+
+export type AnimationStyle = 'slide' | 'swing' | 'none';
+
+const SWING_OVERSHOOT = 0.12;
+const SWING_OVERSHOOT_FRACTION = 0.55;
+
+export class WorkspaceAnimationManager {
+    private _style: AnimationStyle;
+    private _enabled = false;
+
+    private _origCreateBackground = (WorkspaceAnimation as any).WorkspaceBackground.prototype._createBackground;
+    private _origEaseProperty = (WorkspaceAnimation as any).MonitorGroup.prototype.ease_property;
+
+    constructor(style: AnimationStyle = 'swing') {
+        this._style = style;
+    }
+
+    enable(): void {
+        if (this._enabled) return;
+        this._enabled = true;
+
+        (WorkspaceAnimation as any).WorkspaceBackground.prototype._createBackground = function (this: any) { };
+
+        if (this._style === 'swing') this._patchSwing();
+    }
+
+    disable(): void {
+        if (!this._enabled) return;
+        this._enabled = false;
+
+        (WorkspaceAnimation as any).WorkspaceBackground.prototype._createBackground = this._origCreateBackground;
+        (WorkspaceAnimation as any).MonitorGroup.prototype.ease_property = this._origEaseProperty;
+    }
+
+    setStyle(style: AnimationStyle): void {
+        if (style === this._style) return;
+        const wasEnabled = this._enabled;
+        if (wasEnabled) this.disable();
+        this._style = style;
+        if (wasEnabled) this.enable();
+    }
+
+    get style(): AnimationStyle {
+        return this._style;
+    }
+
+    get isEnabled(): boolean {
+        return this._enabled;
+    }
+
+    private _patchSwing(): void {
+        const original = this._origEaseProperty;
+
+        (WorkspaceAnimation as any).MonitorGroup.prototype.ease_property = function (
+            this: any,
+            propertyName: string,
+            target: number,
+            params: any,
+        ) {
+            if (propertyName !== 'progress') {
+                original.call(this, propertyName, target, params);
+                return;
+            }
+
+            const delta = target - this.progress;
+            const overshootDuration = Math.round(params.duration * SWING_OVERSHOOT_FRACTION);
+            const settleDuration = params.duration - overshootDuration;
+
+            original.call(this, propertyName, target + delta * SWING_OVERSHOOT, {
+                duration: overshootDuration,
+                mode: Clutter.AnimationMode.EASE_OUT_CUBIC,
+                onComplete: () => {
+                    original.call(this, propertyName, target, {
+                        duration: settleDuration,
+                        mode: Clutter.AnimationMode.EASE_IN_OUT_CUBIC,
+                        onComplete: params.onComplete,
+                    });
+                },
+            });
+        };
+    }
+}

--- a/src/ui/workspace_animation.ts
+++ b/src/ui/workspace_animation.ts
@@ -24,7 +24,9 @@ export class WorkspaceAnimationManager {
         if (this._enabled) return;
         this._enabled = true;
 
-        (WorkspaceAnimation as any).WorkspaceBackground.prototype._createBackground = function (this: any) { };
+        (WorkspaceAnimation as any).WorkspaceBackground.prototype._createBackground = function (this: any) {
+            this._bgManager = { destroy: () => {} };
+        };
 
         this._patchStaticBackground();
 

--- a/src/ui/workspace_switcher_style.ts
+++ b/src/ui/workspace_switcher_style.ts
@@ -320,12 +320,6 @@ export class WorkspaceSwitcherStyle {
 
     private _setupAutoScroll(): void {
         const workspace_manager = (global as any).workspace_manager;
-        workspace_manager.connectObject('active-workspace-changed', () => {
-            GLib.idle_add(GLib.PRIORITY_DEFAULT_IDLE, () => {
-                this._scrollToActiveWorkspace();
-                return GLib.SOURCE_REMOVE;
-            });
-        }, this);
 
         // 1. Rescale when workspaces are added/removed
         workspace_manager.connectObject('workspace-added', () => {
@@ -341,48 +335,7 @@ export class WorkspaceSwitcherStyle {
         }, this);
     }
 
-    private _scrollToActiveWorkspace(): void {
-        try {
-            const thumbnailsBox = this._getThumbnailsBox();
-            if (!thumbnailsBox) return;
 
-            const workspace_manager = (global as any).workspace_manager;
-            const activeIndex = workspace_manager.get_active_workspace_index();
-
-            if (typeof thumbnailsBox._scrollToActive === 'function') {
-                thumbnailsBox._scrollToActive();
-                return;
-            }
-
-            const children = thumbnailsBox.get_children();
-            const child = children[activeIndex];
-            if (!child) return;
-
-            // Guard: if the child hasn't been allocated yet, skip scrolling —
-            // unallocated boxes carry INT_MIN sentinel values (-2147483648)
-            // which propagate NaN through StDrawingArea/StBin assertions.
-            if (typeof child.has_allocation === 'function' && !child.has_allocation()) return;
-
-            const box = child.get_allocation_box();
-
-            // Sanity-check: reject sentinel / unallocated boxes
-            if (!Number.isFinite(box.x1) || !Number.isFinite(box.x2) ||
-                box.x1 < -1e9 || box.x2 < -1e9) return;
-
-            const childCenter = (box.x1 + box.x2) / 2;
-
-            const scroll = thumbnailsBox.get_parent();
-            if (!scroll) return;
-
-            const adjustment = scroll.get_hadjustment();
-            const pageSize = adjustment.page_size;
-            if (!Number.isFinite(pageSize) || pageSize <= 0) return;
-
-            adjustment.value = childCenter - pageSize / 2;
-        } catch (e) {
-            log.warn(`WorkspaceSwitcherStyle: _scrollToActiveWorkspace failed: ${e}`);
-        }
-    }
 
 
     private _teardownSignals(): void {

--- a/src/utils/lib.ts
+++ b/src/utils/lib.ts
@@ -136,3 +136,33 @@ export function round_to(n: number, digits: number): number {
 export function separator(): any {
     return new St.BoxLayout({ style_class: 'o-tiling-separator', x_expand: true });
 }
+
+// GNOME 48+: maximize/unmaximize always act on both axes.
+export function maximize(window: Meta.Window) {
+    window.maximize();
+}
+
+export function unmaximize(window: Meta.Window) {
+    window.unmaximize();
+}
+
+export function is_maximized(window: Meta.Window): boolean {
+    return window.maximized_horizontally || window.maximized_vertically;
+}
+
+/** Schedules a callback before the next compositor redraw (GNOME 45+ API). */
+export function later_add(type: Meta.LaterType, action: () => boolean | number): number {
+    return (global as any).compositor.get_laters().add(type, action);
+}
+
+/** Removes a previously scheduled later callback (GNOME 45+ API). */
+export function later_remove(id: number) {
+    (global as any).compositor.get_laters().remove(id);
+}
+
+/** Activates a window that is not an override-redirect window. */
+export function activate_window(window: Meta.Window) {
+    // override-redirect windows don't participate in normal focus management
+    if (window.is_override_redirect()) return;
+    window.activate(Clutter.get_current_event_time());
+}

--- a/src/utils/lib.ts
+++ b/src/utils/lib.ts
@@ -44,16 +44,17 @@ export function bench<T>(name: string, callback: () => T): T {
     return value;
 }
 
+export function active_monitor_index(): number {
+    // GNOME 49+ uses get_current_logical_monitor() on backend, while GNOME 48 uses get_current_monitor() on display.
+    if ('get_current_logical_monitor' in (global as any).backend)
+        return (global as any).backend.get_current_logical_monitor().get_number();
+    return (global as any).display.get_current_monitor();
+}
+
 export function current_monitor(): Rectangle {
-    const idx = (global as any).backend.get_current_logical_monitor()?.get_number() ?? 0;
-    const mm = (global as any).backend.get_monitor_manager();
-    const lm = mm ? mm.get_logical_monitors().find((m: any) => m.get_number() === idx) : null;
-    
-    if (lm) {
-        return new rectangle.Rectangle([lm.x, lm.y, lm.width, lm.height]);
-    } else {
-        return new rectangle.Rectangle([0, 0, 1920, 1080]);
-    }
+    const idx = active_monitor_index();
+    const rect = (global as any).display.get_monitor_geometry(idx);
+    return rectangle.Rectangle.from_meta(rect);
 }
 
 // Fetch rectangle that represents the cursor

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -42,6 +42,21 @@ export function read_to_string(path: string): Promise<result.Result<string, erro
     });
 }
 
+export function write_string(path: string, contents: string): Promise<result.Result<void, error.Error>> {
+    const file = Gio.File.new_for_path(path);
+    const bytes = new TextEncoder().encode(contents);
+    return new Promise((resolve) => {
+        file.replace_contents_async(bytes, null, false, Gio.FileCreateFlags.NONE, null, (obj: any, res: any) => {
+            try {
+                obj.replace_contents_finish(res);
+                resolve(Ok(undefined));
+            } catch (e) {
+                resolve(Err(new Error(String(e)).context(`failed to write contents of ${path}`)));
+            }
+        });
+    });
+}
+
 export function source_remove(id: number | null): boolean {
     if (id === null || id <= 0) return false;
     GLib.source_remove(id);

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -4,9 +4,7 @@ import * as log from './log.js';
 
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
-import Meta from 'gi://Meta';
 import GObject from 'gi://GObject';
-import Clutter from 'gi://Clutter';
 const { Ok, Err } = result;
 const { Error } = error;
 
@@ -188,18 +186,6 @@ export function map_eq<K, V>(map1: Map<K, V>, map2: Map<K, V>) {
 }
 
 
-// GNOME 48+: maximize/unmaximize always act on both axes.
-export function maximize(window: Meta.Window) {
-    window.maximize();
-}
-
-export function unmaximize(window: Meta.Window) {
-    window.unmaximize();
-}
-
-export function is_maximized(window: Meta.Window): boolean {
-    return window.maximized_horizontally || window.maximized_vertically;
-}
 
 /** Sets the alpha component of a color string (rgba or hex). */
 export function set_alpha(color: string, alpha: number): string {
@@ -243,19 +229,3 @@ export function isValidColor(color: string): boolean {
     return false;
 }
 
-/** Schedules a callback before the next compositor redraw (GNOME 45+ API). */
-export function later_add(type: Meta.LaterType, action: () => boolean | number): number {
-    return (global as any).compositor.get_laters().add(type, action);
-}
-
-/** Removes a previously scheduled later callback (GNOME 45+ API). */
-export function later_remove(id: number) {
-    (global as any).compositor.get_laters().remove(id);
-}
-
-/** Activates a window that is not an override-redirect window. */
-export function activate_window(window: Meta.Window) {
-    // override-redirect windows don't participate in normal focus management
-    if (window.is_override_redirect()) return;
-    window.activate(Clutter.get_current_event_time());
-}

--- a/src/window/window.ts
+++ b/src/window/window.ts
@@ -583,7 +583,7 @@ export class ShellWindow {
     }
 
     same_monitor() {
-        return this.meta.get_monitor() === ((global as any).backend.get_current_logical_monitor()?.get_number() ?? 0);
+        return this.meta.get_monitor() === lib.active_monitor_index();
     }
 
 
@@ -875,7 +875,7 @@ export function activate(ext: Ext, move_mouse: boolean, win: Meta.Window) {
 
 function pointer_in_work_area(): boolean {
     const cursor = lib.cursor_rect();
-    const indice = (global as any).backend.get_current_logical_monitor()?.get_number() ?? 0;
+    const indice = lib.active_monitor_index();
     const mon = (global as any).workspace_manager.get_active_workspace().get_work_area_for_monitor(indice);
 
     return mon ? cursor.intersects(mon) : false;

--- a/src/window/window.ts
+++ b/src/window/window.ts
@@ -500,7 +500,7 @@ export class ShellWindow {
 
     xid(): string | null {
         return this.extra.xid_.get_or_init(() => {
-            if (utils.is_wayland()) return null;
+            if (this.meta.get_client_type() === Meta.WindowClientType.WAYLAND) return null;
             const desc = this.meta.get_description();
             if (!desc) return null;
             const match = desc.match(/0x[a-f0-9]+/i);

--- a/src/window/window.ts
+++ b/src/window/window.ts
@@ -361,7 +361,7 @@ export class ShellWindow {
     }
 
     is_maximized(): boolean {
-        return utils.is_maximized(this.meta);
+        return lib.is_maximized(this.meta);
     }
 
 
@@ -436,7 +436,7 @@ export class ShellWindow {
 
         if (actor) {
             if (this.is_maximized()) {
-                utils.unmaximize(this.meta);
+                lib.unmaximize(this.meta);
             }
             (actor as any).remove_all_transitions();
 
@@ -655,11 +655,11 @@ export class ShellWindow {
 
         const old_id = this._restack_id;
         this._restack_id = null;
-        if (old_id !== null) utils.later_remove(old_id);
+        if (old_id !== null) lib.later_remove(old_id);
         if (immediate) {
             action();
         } else {
-            id = utils.later_add(Meta.LaterType.BEFORE_REDRAW, action);
+            id = lib.later_add(Meta.LaterType.BEFORE_REDRAW, action);
             this._restack_id = id;
         }
     }
@@ -825,7 +825,7 @@ export class ShellWindow {
     destroy() {
         this.destroying = true;
         if (this._restack_id !== null) {
-            utils.later_remove(this._restack_id);
+            lib.later_remove(this._restack_id);
             this._restack_id = null;
         }
         if (this._border_settle_id !== null) {

--- a/src/window/window.ts
+++ b/src/window/window.ts
@@ -106,7 +106,7 @@ function is_panel_actor(focused_actor: Clutter.Actor | null): boolean {
         ) {
             return true;
         }
-        actor = actor.get_parent?.() ?? null;
+        actor = actor.get_parent();
     }
     return false;
 }
@@ -116,15 +116,15 @@ export function clutter_focus_is_shell_panel(): boolean {
     if (!stage) return false;
 
     // Check if the keyboard focus is on a shell element
-    const key_actor: Clutter.Actor | null = stage.get_key_focus?.() ?? null;
+    const key_actor: Clutter.Actor | null = stage.get_key_focus();
     if (is_panel_actor(key_actor)) return true;
 
     // Check if the pointer is hovering over a shell element
-    const pointer = (global as any).get_pointer?.();
+    const pointer = (global as any).get_pointer();
     if (!pointer) return false;
 
     const [x, y] = pointer;
-    const pointer_actor = stage.get_actor_at_pos?.(1 /* Clutter.PickMode.REACTIVE */, x, y) ?? null;
+    const pointer_actor = stage.get_actor_at_pos(1 /* Clutter.PickMode.REACTIVE */, x, y);
     if (is_panel_actor(pointer_actor)) return true;
 
     return false;
@@ -628,7 +628,7 @@ export class ShellWindow {
             parent.set_child_above_sibling(border, actor);
 
             for (const above_actor of (global as any).get_window_actors()) {
-                const meta = above_actor?.get_meta_window?.();
+                const meta = above_actor.get_meta_window();
                 if (!meta || !meta.is_above()) continue;
                 const above_parent = above_actor.get_parent();
                 if (above_actor !== actor && above_parent === parent) {

--- a/test_ts.py
+++ b/test_ts.py
@@ -1,7 +1,0 @@
-import tree_sitter_javascript as tsjs
-from tree_sitter import Language, Parser
-JS_LANGUAGE = Language(tsjs.language())
-parser = Parser(JS_LANGUAGE)
-with open('dist/extension.js', 'rb') as f:
-    tree = parser.parse(f.read())
-print("Parsed extension.js successfully!")

--- a/test_ts.py
+++ b/test_ts.py
@@ -1,0 +1,7 @@
+import tree_sitter_javascript as tsjs
+from tree_sitter import Language, Parser
+JS_LANGUAGE = Language(tsjs.language())
+parser = Parser(JS_LANGUAGE)
+with open('dist/extension.js', 'rb') as f:
+    tree = parser.parse(f.read())
+print("Parsed extension.js successfully!")


### PR DESCRIPTION

This release branch introduces configurable workspace and window animations, extends compatibility to GNOME 49+, and consolidates several internal utilities for consistency and maintainability.

## Highlights

### New features
- Workspace animation manager with slide and Hyprland-style swing transitions, including static background support during workspace switches
- Configurable window animation manager with a "glide" style effect, replacing the previous "none" animation
- Debug mode setting moved from the panel menu into the main preferences window
- New options to hide the panel icon and relocate controls into GNOME Quick Settings

### Fixes
- Prevented infinite toggle loops in indicator state updates
- Fixed a workspace background initialization memory leak
- Removed obsolete `_scrollToActiveWorkspace` method
- Removed unused `o-tiling-ws-overview-symbolic` icon (replaced with a text label in panel settings)

### Refactors
- Centralized monitor index logic and updated monitor geometry retrieval for GNOME 49+ support
- Reimplemented window animation patching via `mapWindow`/`destroyWindow` hook overrides instead of the previous approach
- Consolidated window teardown logic into a single method for consistency
- Migrated window management and later-callback utilities from `utils.ts` into `lib.ts`
- Replaced custom file I/O with unified utils and made theme updates non-blocking
- Removed optional chaining/nullish coalescing from Clutter method calls for stricter compatibility
- Removed redundant GLib signal cleanup in executor timeout logic and panel settings teardown

### Versioning
- Bumped version 2.9.7 → 2.9.8 → 2.9.9

## Files changed
- 1 file removed (unused icon)
- 2 files added: `src/ui/window_animation.ts`, `src/ui/workspace_animation.ts`
- 16 files modified (core extension, engine, prefs, settings, UI, utils)

## Note
⚠️ `segfault.log` appears to have been committed as part of this branch — worth double-checking whether that was intentional before merging, as it looks like a debug artifact.