### PR TITLE
fix: float wl-clipboard windows to prevent tiling issues

### DIFF
--- a/src/floating_exceptions/config.ts
+++ b/src/floating_exceptions/config.ts
@@ -59,6 +59,7 @@ export const DEFAULT_FLOAT_RULES: Array<FloatRule> = [
     { class: 'zoom' },
     { class: '^.*action=join.*$' },
     { class: 'gjs' },
+    { class: 'io.github.bugaevc.wl-clipboard' },
 ];
 
 export interface WindowRule {

--- a/src/system/config.ts
+++ b/src/system/config.ts
@@ -61,6 +61,7 @@ export const DEFAULT_FLOAT_RULES: Array<FloatRule> = [
     { class: 'zoom' },
     { class: '^.*action=join.*$' },
     { class: 'gjs' },
+    { class: 'io.github.bugaevc.wl-clipboard' },
 ];
 
 export interface WindowRule {


### PR DESCRIPTION
## Problem

Running `wl-copy` causes autotiled windows to briefly flash and resize. This also affects TUI's like OpenCode that use it as a clipboard helper.

https://github.com/user-attachments/assets/453a5f10-a127-4b9c-b2c0-5f2c52fee6d4

## Steps to Reproduce
1. Enable auto-tiling.
2. Run `wl-copy` in a terminal:
   ```bash
   wl-copy "test"
   ```

## Fix
Added `io.github.bugaevc.wl-clipboard` to the default float rules to exclude it from tiling.

https://github.com/user-attachments/assets/4edda954-d02c-49cc-987b-468296b9fbfa