### PR TITLE
Fix: windows swap / workspace flips on lock screen unlock (#42)

### DIFF
--- a/src/engine/auto_tiler.ts
+++ b/src/engine/auto_tiler.ts
@@ -170,7 +170,7 @@ export class AutoTiler {
     }
 
     /** Tile a window onto a workspace */
-    attach_to_workspace(ext: Ext, win: ShellWindow, id: [number, number]) {
+    attach_to_workspace(ext: Ext, win: ShellWindow, id: [number, number], ignore_focus: boolean = false) {
         if (ext.should_ignore_workspace(id[0])) {
             id = [id[0], 0];
         }
@@ -185,20 +185,24 @@ export class AutoTiler {
             );
 
             if (ws_windows.length > 0) {
-                let focus = ext.focus_window();
-
-                if (focus && focus.entity === win.entity) {
-                    const prev_entity = ext.previously_focused(win);
-                    focus = prev_entity ? (ext.windows.get(prev_entity) ?? null) : null;
-                }
-
-                const placement = ext.settings.new_window_placement();
-
-                if (placement !== 'largest' && focus && focus.known_workspace === id[1] && focus.is_tilable(ext) && this.attached.contains(focus.entity)) {
-                    // 'focused' mode: always split the active window (default)
-                    onto = focus;
-                } else {
+                if (ignore_focus) {
                     onto = this.forest.largest_window_on(ext, toplevel);
+                } else {
+                    let focus = ext.focus_window();
+
+                    if (focus && focus.entity === win.entity) {
+                        const prev_entity = ext.previously_focused(win);
+                        focus = prev_entity ? (ext.windows.get(prev_entity) ?? null) : null;
+                    }
+
+                    const placement = ext.settings.new_window_placement();
+
+                    if (placement !== 'largest' && focus && focus.known_workspace === id[1] && focus.is_tilable(ext) && this.attached.contains(focus.entity)) {
+                        // 'focused' mode: always split the active window (default)
+                        onto = focus;
+                    } else {
+                        onto = this.forest.largest_window_on(ext, toplevel);
+                    }
                 }
             }
 
@@ -213,10 +217,10 @@ export class AutoTiler {
     }
 
     /** Automatically tiles a window into the tree, trying the focused window first, then the monitor. */
-    auto_tile(ext: Ext, win: ShellWindow, _ignore_focus?: boolean) {
+    auto_tile(ext: Ext, win: ShellWindow, ignore_focus: boolean = false) {
         this.detach_window(ext, win.entity);
         log.debug(`attach to workspace: finding largest window`);
-        this.attach_to_workspace(ext, win, ext.workspace_id(win));
+        this.attach_to_workspace(ext, win, ext.workspace_id(win), ignore_focus);
     }
 
     /** Destroy all widgets owned by this object. Call before dropping. */

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -73,9 +73,11 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 const {
     layoutManager,
     overview,
+    screenShield,
     sessionMode,
     windowAttentionHandler,
 } = Main;
+import { ScreenShield } from 'resource:///org/gnome/shell/ui/screenShield.js';
 
 import { WindowSwitcherPopup } from 'resource:///org/gnome/shell/ui/altTab.js';
 import { Workspace } from 'resource:///org/gnome/shell/ui/workspace.js';
@@ -249,6 +251,7 @@ export class Ext extends Ecs.System<ExtEvent> {
     /** True while a bulk re-tile rebuild is in progress; suppresses move animation. */
     _batch_moving: boolean = false;
     _unlock_signal_id: number | null = null;
+    was_locked: boolean = false;
     executor: Executor.GLibExecutor<ExtEvent>;
 
     constructor() {
@@ -1113,9 +1116,6 @@ export class Ext extends Ecs.System<ExtEvent> {
     }
 
     injections_add() {
-        const sessionMode = (Main as any).sessionMode;
-        if (!sessionMode) return;
-
         if (this._unlock_signal_id !== null) {
             sessionMode.disconnect(this._unlock_signal_id);
             this._unlock_signal_id = null;
@@ -1127,16 +1127,20 @@ export class Ext extends Ecs.System<ExtEvent> {
             }
 
             if (sessionMode.isLocked) {
-                this.suspend();
-            } else {
-                this.resume();
+                this.exit_modes();
             }
+        });
+
+        const screen_unlock_fn = ScreenShield.prototype['deactivate'];
+        this.inject(ScreenShield.prototype, 'deactivate', (args: any) => {
+            screen_unlock_fn.apply(screenShield, [args]);
+            this.update_display_configuration(true);
         });
     }
 
     injections_remove() {
         if (this._unlock_signal_id !== null) {
-            (Main as any).sessionMode.disconnect(this._unlock_signal_id);
+            sessionMode.disconnect(this._unlock_signal_id);
             this._unlock_signal_id = null;
         }
         for (const { object, method, func } of this.injections.splice(0)) {
@@ -2931,11 +2935,8 @@ export class Ext extends Ecs.System<ExtEvent> {
                 this.keybindings.enable(this.keybindings.global).enable(this.keybindings.window_focus);
             }
             if (this.settings.tile_by_default()) {
-                if (!this.auto_tiler) {
-                    this.auto_tile_on(false);
-                }
+                this.auto_tile_on(false);
 
-                // Secondary retile: catch windows whose compositor actors were not ready during the first pass after suspend
                 const sub_id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 800, () => {
                     if (this._timeouts['resume_timeout_source'] === sub_id) {
                         this._timeouts['resume_timeout_source'] = null;
@@ -3890,6 +3891,11 @@ export default class OTilingExtension extends Extension {
             _hide_skip_taskbar_windows();
         }
 
+        if (ext.was_locked) {
+            ext.was_locked = false;
+            return;
+        }
+
         ext.injections_add();
         ext.signals_attach();
 
@@ -3923,10 +3929,12 @@ export default class OTilingExtension extends Extension {
         setup_osk_signal();
     }
     disable() {
-        // unlock-dialog is listed in session-modes so the extension persists across screen lock/unlock
-        // without destroying and recreating the full window layout tree. On lock we suspend; on unlock
-        // we resume. disable() is therefore called only on extension unload, not on each lock cycle.
         log.info('disable');
+
+        if (ext && sessionMode.isLocked) {
+            ext.was_locked = true;
+            return;
+        }
 
         if (_osk_signal) {
             (layoutManager as any).keyboardBox?.disconnect(_osk_signal);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -248,6 +248,7 @@ export class Ext extends Ecs.System<ExtEvent> {
     private _osk_paused_entity: Entity | null = null;
     /** True while a bulk re-tile rebuild is in progress; suppresses move animation. */
     _batch_moving: boolean = false;
+    _unlock_signal_id: number | null = null;
     executor: Executor.GLibExecutor<ExtEvent>;
 
     constructor() {
@@ -381,7 +382,9 @@ export class Ext extends Ecs.System<ExtEvent> {
 
         const id_hide_panel = this.settings.ext.connect('changed::hide-panel-icon', () => {
             if (indicator) {
-                indicator.button.visible = !this.settings.hide_panel_icon();
+                const sessionMode = (Main as any).sessionMode;
+                const isLocked = sessionMode ? sessionMode.isLocked : false;
+                indicator.button.visible = !isLocked && !this.settings.hide_panel_icon();
             }
         });
         this._settings_signal_ids.push([this.settings.ext, id_hide_panel]);
@@ -1110,9 +1113,32 @@ export class Ext extends Ecs.System<ExtEvent> {
     }
 
     injections_add() {
+        const sessionMode = (Main as any).sessionMode;
+        if (!sessionMode) return;
+
+        if (this._unlock_signal_id !== null) {
+            sessionMode.disconnect(this._unlock_signal_id);
+            this._unlock_signal_id = null;
+        }
+
+        this._unlock_signal_id = sessionMode.connect('updated', () => {
+            if (indicator) {
+                indicator.button.visible = !sessionMode.isLocked && !this.settings.hide_panel_icon();
+            }
+
+            if (sessionMode.isLocked) {
+                this.suspend();
+            } else {
+                this.resume();
+            }
+        });
     }
 
     injections_remove() {
+        if (this._unlock_signal_id !== null) {
+            (Main as any).sessionMode.disconnect(this._unlock_signal_id);
+            this._unlock_signal_id = null;
+        }
         for (const { object, method, func } of this.injections.splice(0)) {
             object[method] = func;
         }
@@ -2632,6 +2658,8 @@ export class Ext extends Ecs.System<ExtEvent> {
             if (!this._signals_attached) return; // guard re-entry
             if (this._focused_signal_connected) return; // ADD this flag
             this._focused_signal_connected = true;
+
+            if ((Main as any).sessionMode?.isLocked) this.update_display_configuration(false);
 
             this.connect((global as any).display, 'notify::focus-window', (display: any, window: any) => {
                 // Disallow refocus if a modal window is active (GNOME 48+: Main.modalCount)


### PR DESCRIPTION
## Problem

Windows visibly swap position (and the active workspace sometimes
flips) for about a second after unlocking the screen. Reported in #42.

## Root cause

`session-modes` in `metadata.json` only declares `"user"`, so GNOME
Shell calls `disable()` on screen lock and `enable()` again on unlock —
same as any real extension disable/enable. The previous fix added a
`suspend()`/`resume()` debounce pair triggered from `sessionMode`'s
`'updated'` signal, but that code never actually ran in this path,
because `disable()` unconditionally tore down the whole tiling tree
(`ext.destroy(); ext = null;`) regardless of *why* it was called. On
unlock, `enable()` then rebuilt the tree from scratch using
current-focus heuristics, which don't always match the pre-lock
layout — hence the visible swap.

## Fix

- `disable()`/`enable()` now short-circuit via a `was_locked` flag
  when the call is happening because of a lock/unlock, leaving all
  signals and the tiling tree untouched — same pattern used by
  pop-shell and the Mosaic fork.
- Lock handling itself is simplified to `exit_modes()`, dropping the
  suspend/resume debounce machinery.
- `ScreenShield.prototype.deactivate` is injected (and restored on
  real disable) to resync monitor/workarea geometry on the actual
  unlock event, instead of guessing with timers.
- `resume()` (still used by `suspend_for()`) now always does a full
  `auto_tile_on()` retile rather than skipping it when `auto_tiler`
  is already set.

## Testing

- `npx tsc --noEmit` — clean
- `npm run build` — clean
- Manually tested lock/unlock on GNOME Shell 50: tiling layout and
  active workspace are preserved across lock, no swap/flip observed.

Fixes #42