### PR TITLE
fix: remove active hint border immediately when toggled off

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1417,6 +1417,11 @@ export class Ext extends Ecs.System<ExtEvent> {
     }
 
     show_border_on_focused() {
+        if (!this.settings.active_hint()) {
+            this.hide_all_borders();
+            return;
+        }
+
         const overlay_all = this.settings.active_hint_overlay_all_windows();
         if (overlay_all) {
             for (const window of this.windows.values()) {

--- a/src/window/window.ts
+++ b/src/window/window.ts
@@ -523,6 +523,7 @@ export class ShellWindow {
 
             const permitted = () =>
                 this.actor_exists() &&
+                this.ext.settings.active_hint() &&
                 this.ext.focus_window() == this &&
                 !this.meta.is_fullscreen() &&
                 (!this.is_maximized() || this.is_snap_edge()) &&


### PR DESCRIPTION
## Problem

When toggling off the Active Hint in quick settings the Active Hint border is still shown until window focus changes.

**Expected behavior:** When the Active Hint is toggled off in the quick settings it should disappear immediately without requiring the user to change window focus.

https://github.com/user-attachments/assets/a8034395-636f-44b7-8d01-003dce24b974

## Solution

show_border_on_focused() returned early via the same-window "skip redraw" optimization, so toggling Active Hint off left the border visible until focus changed. This adds a guard at the entry point of show_border_on_focused() that hides all borders whenever the setting is off, and adds the setting to the permitted() predicate so the 150ms deferred re-show timer can't resurrect a border after disable.


https://github.com/user-attachments/assets/3128ba3e-c528-4e81-b213-62b1a4a2537a

