### PR TITLE
Refactor stack/tab-bar creation and anchor to window rect

### DIFF
--- a/src/engine/reconstruct.ts
+++ b/src/engine/reconstruct.ts
@@ -22,6 +22,49 @@ function sort_by_stacking(windows: ShellWindow[]): ShellWindow[] {
     return [...windows].sort((a, b) => (order.get(a.meta) ?? -1) - (order.get(b.meta) ?? -1));
 }
 
+/**
+ * Builds a Stack node from a group of overlapping windows and lays out its tab bar.
+ * Shared by `reconstruct_workspace` and `subtree` so the reconstructed tab bar always
+ * matches the same stack-creation path used elsewhere in the tiler.
+ */
+function build_stack_node(
+    ext: Ext,
+    tiler: AutoTiler,
+    windows: ShellWindow[],
+    workspace: number,
+    monitor: number,
+    area: Rectangle,
+): node.Node {
+    const stacked_windows = sort_by_stacking(windows);
+    const primary = stacked_windows[0];
+    const active_window = stacked_windows[stacked_windows.length - 1];
+
+    const stack_idx = tiler.forest.stacks.insert(new Stack(ext, active_window.entity, workspace, monitor));
+    const stack_node = node.Node.stacked(primary.entity, stack_idx);
+    const inner = stack_node.inner as node.NodeStack;
+    for (let i = 1; i < stacked_windows.length; i++) {
+        inner.entities.push(stacked_windows[i].entity);
+    }
+
+    const container = tiler.forest.stacks.get(stack_idx);
+    if (container) {
+        const tab_height = stack.TAB_HEIGHT * ext.dpi;
+        const content_rect = area.clone();
+        content_rect.y += tab_height;
+        content_rect.height -= tab_height;
+        inner.rect = content_rect;
+
+        for (const win of stacked_windows) {
+            win.stack = stack_idx;
+            container.add(win);
+        }
+        container.update_positions(content_rect);
+        container.activate(active_window.entity);
+    }
+
+    return stack_node;
+}
+
 /** Reconstruct a tiling layout for all windows on a single [monitor, workspace] using BSP tree inspection. */
 export function reconstruct_workspace(
     tiler: AutoTiler,
@@ -58,16 +101,8 @@ export function reconstruct_workspace(
     }
 
     if (all_stacked) {
-        const stacked_windows = sort_by_stacking(windows);
-        const primary = stacked_windows[0];
-        const active_window = stacked_windows[stacked_windows.length - 1];
-
-        const stack_idx = tiler.forest.stacks.insert(new Stack(ext, active_window.entity, workspace, monitor));
-        const stack_node = node.Node.stacked(primary.entity, stack_idx);
+        const stack_node = build_stack_node(ext, tiler, windows, workspace, monitor, root_area);
         const inner = stack_node.inner as node.NodeStack;
-        for (let i = 1; i < stacked_windows.length; i++) {
-            inner.entities.push(stacked_windows[i].entity);
-        }
 
         const [fork_entity, fork] = tiler.forest.create_fork(stack_node, null, root_area.clone(), workspace, monitor);
         fork.is_toplevel = true;
@@ -75,22 +110,6 @@ export function reconstruct_workspace(
 
         for (const ent of inner.entities) {
             ext.on_tile_attach(fork_entity, ent);
-        }
-
-        const container = tiler.forest.stacks.get(stack_idx);
-        if (container) {
-            const tab_height = stack.TAB_HEIGHT * ext.dpi;
-            const content_rect = root_area.clone();
-            content_rect.y += tab_height;
-            content_rect.height -= tab_height;
-            inner.rect = content_rect;
-
-            for (const win of stacked_windows) {
-                win.stack = stack_idx;
-                container.add(win);
-            }
-            container.update_positions(content_rect);
-            container.activate(active_window.entity);
         }
         return;
     }
@@ -133,33 +152,7 @@ function subtree(
     });
 
     if (is_stacked) {
-        const stacked_windows = sort_by_stacking(windows);
-        const primary = stacked_windows[0];
-        const active_window = stacked_windows[stacked_windows.length - 1];
-
-        const stack_idx = tiler.forest.stacks.insert(new Stack(ext, active_window.entity, workspace, monitor));
-        const stack_node = node.Node.stacked(primary.entity, stack_idx);
-        const inner = stack_node.inner as node.NodeStack;
-        for (let i = 1; i < stacked_windows.length; i++) {
-            inner.entities.push(stacked_windows[i].entity);
-        }
-
-        const container = tiler.forest.stacks.get(stack_idx);
-        if (container) {
-            const tab_height = stack.TAB_HEIGHT * ext.dpi;
-            const content_rect = area.clone();
-            content_rect.y += tab_height;
-            content_rect.height -= tab_height;
-            inner.rect = content_rect;
-
-            for (const win of stacked_windows) {
-                win.stack = stack_idx;
-                container.add(win);
-            }
-            container.update_positions(content_rect);
-            container.activate(active_window.entity);
-        }
-        return stack_node;
+        return build_stack_node(ext, tiler, windows, workspace, monitor, area);
     }
 
     // Try a horizontal split (left/right groups)

--- a/src/engine/reconstruct.ts
+++ b/src/engine/reconstruct.ts
@@ -22,18 +22,12 @@ function sort_by_stacking(windows: ShellWindow[]): ShellWindow[] {
     return [...windows].sort((a, b) => (order.get(a.meta) ?? -1) - (order.get(b.meta) ?? -1));
 }
 
-/**
- * Builds a Stack node from a group of overlapping windows and lays out its tab bar.
- * Shared by `reconstruct_workspace` and `subtree` so the reconstructed tab bar always
- * matches the same stack-creation path used elsewhere in the tiler.
- */
 function build_stack_node(
     ext: Ext,
     tiler: AutoTiler,
     windows: ShellWindow[],
     workspace: number,
     monitor: number,
-    area: Rectangle,
 ): node.Node {
     const stacked_windows = sort_by_stacking(windows);
     const primary = stacked_windows[0];
@@ -49,7 +43,8 @@ function build_stack_node(
     const container = tiler.forest.stacks.get(stack_idx);
     if (container) {
         const tab_height = stack.TAB_HEIGHT * ext.dpi;
-        const content_rect = area.clone();
+
+        const content_rect = active_window.rect();
         content_rect.y += tab_height;
         content_rect.height -= tab_height;
         inner.rect = content_rect;
@@ -101,7 +96,7 @@ export function reconstruct_workspace(
     }
 
     if (all_stacked) {
-        const stack_node = build_stack_node(ext, tiler, windows, workspace, monitor, root_area);
+        const stack_node = build_stack_node(ext, tiler, windows, workspace, monitor);
         const inner = stack_node.inner as node.NodeStack;
 
         const [fork_entity, fork] = tiler.forest.create_fork(stack_node, null, root_area.clone(), workspace, monitor);
@@ -152,7 +147,7 @@ function subtree(
     });
 
     if (is_stacked) {
-        return build_stack_node(ext, tiler, windows, workspace, monitor, area);
+        return build_stack_node(ext, tiler, windows, workspace, monitor);
     }
 
     // Try a horizontal split (left/right groups)

--- a/src/engine/reconstruct.ts
+++ b/src/engine/reconstruct.ts
@@ -11,55 +11,6 @@ import type { ShellWindow } from '../window/window.js';
 
 const { Stack } = stack;
 
-function sort_by_stacking(windows: ShellWindow[]): ShellWindow[] {
-    const order = new Map<any, number>();
-    const actors = (global as any).get_window_actors();
-    for (let i = 0; i < actors.length; i++) {
-        const meta = actors[i].get_meta_window();
-        if (meta) order.set(meta, i);
-    }
-
-    return [...windows].sort((a, b) => (order.get(a.meta) ?? -1) - (order.get(b.meta) ?? -1));
-}
-
-function build_stack_node(
-    ext: Ext,
-    tiler: AutoTiler,
-    windows: ShellWindow[],
-    workspace: number,
-    monitor: number,
-): node.Node {
-    const stacked_windows = sort_by_stacking(windows);
-    const primary = stacked_windows[0];
-    const active_window = stacked_windows[stacked_windows.length - 1];
-
-    const stack_idx = tiler.forest.stacks.insert(new Stack(ext, active_window.entity, workspace, monitor));
-    const stack_node = node.Node.stacked(primary.entity, stack_idx);
-    const inner = stack_node.inner as node.NodeStack;
-    for (let i = 1; i < stacked_windows.length; i++) {
-        inner.entities.push(stacked_windows[i].entity);
-    }
-
-    const container = tiler.forest.stacks.get(stack_idx);
-    if (container) {
-        const tab_height = stack.TAB_HEIGHT * ext.dpi;
-
-        const content_rect = active_window.rect();
-        content_rect.y += tab_height;
-        content_rect.height -= tab_height;
-        inner.rect = content_rect;
-
-        for (const win of stacked_windows) {
-            win.stack = stack_idx;
-            container.add(win);
-        }
-        container.update_positions(content_rect);
-        container.activate(active_window.entity);
-    }
-
-    return stack_node;
-}
-
 /** Reconstruct a tiling layout for all windows on a single [monitor, workspace] using BSP tree inspection. */
 export function reconstruct_workspace(
     tiler: AutoTiler,
@@ -87,26 +38,34 @@ export function reconstruct_workspace(
         );
     });
 
-    const root_area = ext.monitor_work_area(monitor);
-    if (!ext.settings.smart_gaps()) {
-        root_area.x += ext.gap_outer;
-        root_area.y += ext.gap_top;
-        root_area.width -= ext.gap_outer * 2;
-        root_area.height -= ext.gap_outer + ext.gap_top;
-    }
-
     if (all_stacked) {
-        const stack_node = build_stack_node(ext, tiler, windows, workspace, monitor);
+        const primary = windows[0];
+        const stack_idx = tiler.forest.stacks.insert(new Stack(ext, primary.entity, workspace, monitor));
+        const stack_node = node.Node.stacked(primary.entity, stack_idx);
         const inner = stack_node.inner as node.NodeStack;
+        for (let i = 1; i < windows.length; i++) {
+            inner.entities.push(windows[i].entity);
+        }
 
-        const [fork_entity, fork] = tiler.forest.create_fork(stack_node, null, root_area.clone(), workspace, monitor);
+        const area = ext.monitor_work_area(monitor);
+        const [fork_entity, fork] = tiler.forest.create_fork(stack_node, null, area.clone(), workspace, monitor);
         fork.is_toplevel = true;
         tiler.forest.toplevel.set(`${fork_entity}`, [fork_entity, [monitor, workspace]]);
 
         for (const ent of inner.entities) {
             ext.on_tile_attach(fork_entity, ent);
         }
+
+        populate_stack_tabs(tiler, ext, inner, primary);
         return;
+    }
+
+    const root_area = ext.monitor_work_area(monitor);
+    if (!ext.settings.smart_gaps()) {
+        root_area.x += ext.gap_outer;
+        root_area.y += ext.gap_top;
+        root_area.width -= ext.gap_outer * 2;
+        root_area.height -= ext.gap_outer + ext.gap_top;
     }
 
     const root_node = subtree(ext, tiler, monitor, workspace, windows, root_area);
@@ -118,6 +77,16 @@ export function reconstruct_workspace(
             tiler.forest.toplevel.set(`${root_fork_entity}`, [root_fork_entity, [monitor, workspace]]);
         }
     }
+}
+
+function populate_stack_tabs(
+    tiler: AutoTiler,
+    ext: Ext,
+    inner: node.NodeStack,
+    primary: ShellWindow,
+) {
+    inner.rect = primary.rect();
+    tiler.update_stack(ext, inner);
 }
 
 function subtree(
@@ -147,7 +116,16 @@ function subtree(
     });
 
     if (is_stacked) {
-        return build_stack_node(ext, tiler, windows, workspace, monitor);
+        const primary = windows[0];
+        const stack_idx = tiler.forest.stacks.insert(new Stack(ext, primary.entity, workspace, monitor));
+        const stack_node = node.Node.stacked(primary.entity, stack_idx);
+        const inner = stack_node.inner as node.NodeStack;
+        for (let i = 1; i < windows.length; i++) {
+            inner.entities.push(windows[i].entity);
+        }
+
+        populate_stack_tabs(tiler, ext, inner, primary);
+        return stack_node;
     }
 
     // Try a horizontal split (left/right groups)


### PR DESCRIPTION
## Problem

After resume from suspend (or a re-enable that goes through the same "soft" path), stacked/tabbed windows lose their tab bar even though the windows themselves are still correctly grouped into the same tile slot.

## Root cause

The resume/re-enable path calls:

```js
ext.auto_tile_on(false, false); // save_setting=false, reposition=false
```

`reposition = false` is intentional — windows are already in the right place and shouldn't be moved again. But the `reposition` block in `auto_tile_on` is *also* the only code path that runs `forest.tile()` → `fork.measure()` → `forest.arrange()`. For a stack node, `Node.measure()` is what queues `[stack, parent]` into `forest.stack_updates`, and `arrange()` is what flushes that queue via `AutoTiler.update_stack()` — the function that actually calls `container.add(window)` and builds the `TabButton` widgets.

With `reposition = false`, that whole pipeline is skipped, so:
- `reconstruct.ts` still rebuilds the fork/stack tree and calls `on_tile_attach()` → windows correctly land in the same tile slot ✅
- but `update_stack()` never runs → no tab buttons are ever created → tab bar is empty/gone ❌

## Fix

`reconstruct.ts` now calls `AutoTiler.update_stack()` directly, right after building each stack node, instead of relying on the deferred `stack_updates` queue that only gets flushed by a full reposition pass. The stack's rect is anchored to the primary window's current on-screen frame rect, so this only builds the tab bar UI — it doesn't move any windows.

Applied in both places a stack node gets reconstructed:
- `reconstruct_workspace()` (all-windows-overlapping case)
- `subtree()` (recursive BSP case)

## Testing

- `pnpm run type-check` — passes
- `pnpm run lint` — passes
- Manually verified: stack 3 windows → suspend → resume → tab bar is present with all 3 tabs, correct active tab, correct titles/icons, clicking tabs still switches windows.