### PR TITLE
fix: known_workspace synchronization when attaching windows 

### DIFF
--- a/src/engine/auto_tiler.ts
+++ b/src/engine/auto_tiler.ts
@@ -175,6 +175,8 @@ export class AutoTiler {
             id = [id[0], 0];
         }
 
+        win.known_workspace = id[1];
+
         const toplevel = this.forest.find_toplevel(id);
 
         if (toplevel) {


### PR DESCRIPTION
attach_to_workspace() decided whether an incoming window should split against an existing window on the target workspace by filtering on known_workspace, but nothing updated that field when a window was individually sent to another workspace (only Fork.migrate() did, for whole-toplevel migrations). The moved window kept its stale known_workspace, so it never matched the filter, attach_to_workspace fell through to attach_to_monitor() again, and a second toplevel fork was created on top of the first, orphaning the moved window (#78).