### PR TITLE
fix: persist disabled_workspaces across disable/enable

### DIFF
--- a/schemas/org.gnome.shell.extensions.o-tiling.gschema.xml
+++ b/schemas/org.gnome.shell.extensions.o-tiling.gschema.xml
@@ -400,6 +400,11 @@
         </key>
 
         <!-- Internal bookkeeping (not user-facing) -->
+        <key type="s" name="disabled-workspaces">
+            <default>'[]'</default>
+            <summary>Internal: JSON array of workspace indices where tiling is manually disabled, so it survives disable/enable (lock, suspend). Do not edit.</summary>
+        </key>
+
         <key type="s" name="cleared-system-bindings">
             <default>'{}'</default>
             <summary>Internal: JSON record of cleared system keybindings, for restore after reboot. Do not edit.</summary>

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -265,6 +265,7 @@ export class Ext extends Ecs.System<ExtEvent> {
         // settings must exist before keybindings (reads cleared-system-bindings)
         this.settings = new Settings.ExtensionSettings();
         this.keybindings = new Keybindings.Keybindings(this);
+        this.load_disabled_workspaces();
 
         // Prevent GNOME Shell Wayland crashes inside focus_on_pointer_rest_callback
         this._original_focus_change_on_pointer_rest = null;
@@ -1217,6 +1218,26 @@ export class Ext extends Ecs.System<ExtEvent> {
         return !this.disabled_workspaces.has(id);
     }
 
+    load_disabled_workspaces() {
+        try {
+            const raw = this.settings.disabled_workspaces_raw();
+            const parsed: number[] = raw ? JSON.parse(raw) : [];
+            const n = wom.get_n_workspaces();
+            this.disabled_workspaces = new Set(parsed.filter(id => id >= 0 && id < n));
+        } catch (e) {
+            log.error(`failed to parse persisted disabled workspaces: ${e}`);
+            this.disabled_workspaces = new Set();
+        }
+    }
+
+    private persist_disabled_workspaces() {
+        try {
+            this.settings.set_disabled_workspaces_raw(JSON.stringify([...this.disabled_workspaces]));
+        } catch (e) {
+            log.error(`failed to persist disabled workspaces: ${e}`);
+        }
+    }
+
     workspace_tiling_set(id: number, tiled: boolean) {
         if (tiled) {
             this.disabled_workspaces.delete(id);
@@ -1239,6 +1260,8 @@ export class Ext extends Ecs.System<ExtEvent> {
                 }
             }
         }
+
+        this.persist_disabled_workspaces();
 
         if (indicator) {
             indicator.update_workspace_tiling_state();

--- a/src/system/settings.ts
+++ b/src/system/settings.ts
@@ -79,6 +79,7 @@ const HINT_COLOR_RGBA = 'hint-color-rgba';
 const DEFAULT_RGBA_COLOR = 'rgba(53, 132, 228, 1)'; // Aura Blue
 const LOG_LEVEL = 'log-level';
 const CLEARED_SYSTEM_BINDINGS = 'cleared-system-bindings';
+const DISABLED_WORKSPACES = 'disabled-workspaces';
 const SHOW_SKIPTASKBAR = 'show-skip-taskbar';
 const MOUSE_CURSOR_FOLLOWS_ACTIVE_WINDOW = 'mouse-cursor-follows-active-window';
 const MOUSE_CURSOR_FOCUS_LOCATION = 'mouse-cursor-focus-location';
@@ -236,6 +237,10 @@ export class ExtensionSettings {
     /** Used by system/keybindings.ts to survive process death. */
     cleared_system_bindings_raw(): string {
         return this.ext.get_string(CLEARED_SYSTEM_BINDINGS);
+    }
+
+    disabled_workspaces_raw(): string {
+        return this.ext.get_string(DISABLED_WORKSPACES);
     }
 
     show_skiptaskbar(): boolean {
@@ -442,6 +447,10 @@ export class ExtensionSettings {
 
     set_cleared_system_bindings_raw(json: string) {
         this.ext.set_string(CLEARED_SYSTEM_BINDINGS, json);
+    }
+
+    set_disabled_workspaces_raw(json: string) {
+        this.ext.set_string(DISABLED_WORKSPACES, json);
     }
 
     set_show_skiptaskbar(set: boolean) {


### PR DESCRIPTION
disabled_workspaces was in-memory only, so lock/suspend reset every per-workspace tiling toggle. Persist it to a gsettings string key, same pattern as cleared-system-bindings. Indices outside the current workspace count are dropped on load so a workspace reaped while disabled can't have its state silently inherited by an unrelated workspace created later at the same index.