### PR TITLE
Fix lifecycle cleanup and settings restoration issues

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3179,8 +3179,13 @@ export class Ext extends Ecs.System<ExtEvent> {
             this.workspace_animation_handler = null;
         } else {
             if (!this.workspace_animation_handler) {
-                this.workspace_animation_handler = new WorkspaceAnimationManager(style);
-                this.workspace_animation_handler.enable();
+                const handler = new WorkspaceAnimationManager(style);
+                if (handler.enable()) {
+                    this.workspace_animation_handler = handler;
+                } else {
+                    style = 'none';
+                    this.settings.set_workspace_animation_style(style);
+                }
             } else {
                 this.workspace_animation_handler.setStyle(style);
             }
@@ -3768,6 +3773,7 @@ declare global {
 
 // Kept at module level so signals_remove() (called from ext_soft_disable) cannot disconnect it.
 let _osk_signal: SignalID = 0;
+let _osk_startup_signal: SignalID = 0;
 
 export default class OTilingExtension extends Extension {
     enable() {
@@ -3795,8 +3801,9 @@ export default class OTilingExtension extends Extension {
             };
 
             if ((layoutManager as any)._startingUp) {
-                const id = layoutManager.connect('startup-complete', () => {
-                    layoutManager.disconnect(id);
+                _osk_startup_signal = layoutManager.connect('startup-complete', () => {
+                    layoutManager.disconnect(_osk_startup_signal);
+                    _osk_startup_signal = 0;
                     register_osk_signal();
                 });
             } else {
@@ -3862,6 +3869,11 @@ export default class OTilingExtension extends Extension {
     disable() {
 
         log.info('disable');
+
+        if (_osk_startup_signal) {
+            layoutManager.disconnect(_osk_startup_signal);
+            _osk_startup_signal = 0;
+        }
 
         if (_osk_signal) {
             (layoutManager as any).keyboardBox?.disconnect(_osk_signal);

--- a/src/prefs.ts
+++ b/src/prefs.ts
@@ -179,10 +179,15 @@ export default class OTilingPreferences extends ExtensionPreferences {
         overviewGroup.add(wsAnimRow);
         // Map setting value to combo index: 0=none, 1=slide, 2=swing
         const wsAnimValues: string[] = ['none', 'slide', 'swing'];
-        wsAnimRow.set_selected(Math.max(0, wsAnimValues.indexOf(settings.get_string('workspace-animation-style'))));
+        const syncWsAnimRow = () => {
+            const idx = Math.max(0, wsAnimValues.indexOf(settings.get_string('workspace-animation-style')));
+            if (wsAnimRow.selected !== idx) wsAnimRow.set_selected(idx);
+        };
+        syncWsAnimRow();
         wsAnimRow.connect('notify::selected', () => {
             settings.set_string('workspace-animation-style', wsAnimValues[wsAnimRow.selected] ?? 'none');
         });
+        settings.connect('changed::workspace-animation-style', syncWsAnimRow);
 
         const winAnimRow = new Adw.ComboRow({
             title: _('Window Animations'),

--- a/src/system/keybindings.ts
+++ b/src/system/keybindings.ts
@@ -17,10 +17,25 @@ interface ClearedBinding {
     schema_id: string;
     key: string;
     accelerator: string;
+    expected?: string[];
 }
 
 const MODIFIER_ALIASES: Record<string, string> = {
-    '<Primary>': '<Control>',
+    primary: '<Control>',
+    control: '<Control>',
+    ctrl: '<Control>',
+    ctl: '<Control>',
+    shift: '<Shift>',
+    shft: '<Shift>',
+    alt: '<Alt>',
+    mod1: '<Alt>',
+    mod2: '<Mod2>',
+    mod3: '<Mod3>',
+    mod4: '<Mod4>',
+    mod5: '<Mod5>',
+    meta: '<Meta>',
+    hyper: '<Hyper>',
+    super: '<Super>',
 };
 
 function normalize_accelerator(accelerator: string): string | null {
@@ -31,7 +46,7 @@ function normalize_accelerator(accelerator: string): string | null {
     const modifier_pattern = /<[^<>]+>/g;
     let match: RegExpExecArray | null;
     while ((match = modifier_pattern.exec(accelerator)) !== null) {
-        const token = MODIFIER_ALIASES[match[0]] ?? match[0];
+        const token = MODIFIER_ALIASES[match[0].slice(1, -1).toLowerCase()] ?? match[0];
         modifiers.push(token);
     }
     const rest = accelerator.replace(modifier_pattern, '');
@@ -42,6 +57,15 @@ function normalize_accelerator(accelerator: string): string | null {
 
     modifiers.sort();
     return `${modifiers.join('')}${key}`;
+}
+
+function accelerators_equal(left: string[], right: string[] | undefined): boolean {
+    if (!Array.isArray(right) || left.length !== right.length) return false;
+
+    const normalized = (values: string[]) =>
+        values.map((value) => normalize_accelerator(value) ?? value).sort();
+    const normalized_right = normalized(right);
+    return normalized(left).every((value, index) => value === normalized_right[index]);
 }
 
 export class Keybindings {
@@ -91,26 +115,24 @@ export class Keybindings {
         }
     }
 
+    private record_system_write(schema_id: string, key: string, before: string[], after: string[]) {
+        for (const entries of this.cleared_system_bindings.values()) {
+            for (const entry of entries) {
+                if (entry.schema_id === schema_id && entry.key === key) {
+                    entry.expected = accelerators_equal(before, entry.expected) ? [...after] : undefined;
+                }
+            }
+        }
+    }
+
     // Restore bindings left cleared by an unclean shutdown (reboot/logout/crash).
     // No-op after a clean disable(), since restore_conflicts() empties the store.
     private restore_orphaned_bindings() {
         const persisted = this.load_persisted_cleared_bindings();
         if (persisted.size === 0) return;
 
-        for (const entries of persisted.values()) {
-            for (const { schema_id, key, accelerator } of entries) {
-                const settings = this.get_system_settings(schema_id);
-                if (!settings) continue;
-
-                const current: string[] = settings.get_strv(key);
-                if (current.includes(accelerator)) continue;
-
-                settings.set_strv(key, [...current, accelerator]);
-            }
-        }
-
-        this.cleared_system_bindings = new Map();
-        this.persist_cleared_bindings();
+        this.cleared_system_bindings = persisted;
+        for (const name of [...persisted.keys()]) this.restore_conflicts(name);
     }
 
     private resolve_conflicts(name: string, accelerators: string[]) {
@@ -133,11 +155,12 @@ export class Keybindings {
                     if (remaining.length === current.length) continue;
 
                     settings.set_strv(key, remaining);
+                    this.record_system_write(schema_id, key, current, remaining);
 
                     const removed = current.filter((existing) => normalize_accelerator(existing) === target);
                     const entries = this.cleared_system_bindings.get(name) ?? [];
                     for (const removed_accel of removed) {
-                        entries.push({ schema_id, key, accelerator: removed_accel });
+                        entries.push({ schema_id, key, accelerator: removed_accel, expected: [...remaining] });
                     }
                     this.cleared_system_bindings.set(name, entries);
                     this.persist_cleared_bindings();
@@ -150,14 +173,31 @@ export class Keybindings {
         const entries = this.cleared_system_bindings.get(name);
         if (!entries) return;
 
-        for (const { schema_id, key, accelerator } of entries) {
+        const settings_to_restore = new Map<string, ClearedBinding[]>();
+        for (const entry of entries) {
+            const id = `${entry.schema_id}\0${entry.key}`;
+            const grouped = settings_to_restore.get(id) ?? [];
+            grouped.push(entry);
+            settings_to_restore.set(id, grouped);
+        }
+
+        for (const grouped of settings_to_restore.values()) {
+            const [{ schema_id, key }] = grouped;
             const settings = this.get_system_settings(schema_id);
             if (!settings) continue;
 
             const current: string[] = settings.get_strv(key);
-            if (current.includes(accelerator)) continue;
+            const restorable = grouped.filter(({ expected }) => accelerators_equal(current, expected));
+            if (restorable.length === 0) continue;
 
-            settings.set_strv(key, [...current, accelerator]);
+            const restored = [...current];
+            for (const { accelerator } of restorable) {
+                const target = normalize_accelerator(accelerator);
+                if (restored.some((value) => normalize_accelerator(value) === target)) continue;
+                restored.push(accelerator);
+            }
+            settings.set_strv(key, restored);
+            this.record_system_write(schema_id, key, current, restored);
         }
 
         this.cleared_system_bindings.delete(name);

--- a/src/system/window_buttons.ts
+++ b/src/system/window_buttons.ts
@@ -5,6 +5,7 @@ export class WindowButtonsManager {
     private _settings: ExtensionSettings;
     private _signalIds: number[] = [];
     private _originalLayout: string | null = null;   // ← save original
+    private _lastWrittenLayout: string | null = null;
 
     constructor(settings: ExtensionSettings) {
         this._settings = settings;
@@ -34,10 +35,15 @@ export class WindowButtonsManager {
         this._signalIds = [];
 
         // Restore the original layout when the extension is disabled
-        if (this._originalLayout !== null && this._settings.wm) {
+        if (
+            this._originalLayout !== null &&
+            this._lastWrittenLayout !== null &&
+            this._settings.wm?.get_string('button-layout') === this._lastWrittenLayout
+        ) {
             this._settings.wm.set_string('button-layout', this._originalLayout);
-            this._originalLayout = null;
         }
+        this._originalLayout = null;
+        this._lastWrittenLayout = null;
     }
 
     /** Synchronizes the global GNOME button layout with the extension settings. */
@@ -83,5 +89,6 @@ export class WindowButtonsManager {
 
         const new_layout = `${BtnLeft.join(',')}:${BtnRight.join(',')}`;
         wm.set_string('button-layout', new_layout);
+        this._lastWrittenLayout = new_layout;
     }
 }

--- a/src/ui/workspace_animation.ts
+++ b/src/ui/workspace_animation.ts
@@ -15,7 +15,7 @@ export class WorkspaceAnimationManager {
     private _style: AnimationStyle;
     private _enabled = false;
 
-    private _origCreateBackground = (WorkspaceAnimation as any).WorkspaceBackground.prototype._createBackground;
+    private _origCreateBackground = (WorkspaceAnimation as any).WorkspaceBackground?.prototype?._createBackground;
     private _origEaseProperty = (WorkspaceAnimation as any).MonitorGroup.prototype.ease_property;
     private _origPrepareWorkspaceSwitch = (WorkspaceAnimation as any).WorkspaceAnimationController.prototype._prepareWorkspaceSwitch;
     private _warmManagers: Map<number, { container: Meta.BackgroundGroup; manager: any }> = new Map();
@@ -26,8 +26,12 @@ export class WorkspaceAnimationManager {
         this._style = style;
     }
 
-    enable(): void {
-        if (this._enabled) return;
+    enable(): boolean {
+        if (this._enabled) return true;
+        if (typeof this._origCreateBackground !== 'function') {
+            log.warn('WorkspaceAnimationManager: WorkspaceBackground is unavailable; animation disabled');
+            return false;
+        }
         this._enabled = true;
 
         (WorkspaceAnimation as any).WorkspaceBackground.prototype._createBackground = function (this: any) {
@@ -46,9 +50,11 @@ export class WorkspaceAnimationManager {
         this._patchSyncStackingGuard();
 
         if (this._style === 'swing') this._patchSwing();
+        return true;
     }
 
     disable(): void {
+        if (!this._enabled) return;
         this._enabled = false;
 
         (WorkspaceAnimation as any).WorkspaceBackground.prototype._createBackground = this._origCreateBackground;


### PR DESCRIPTION
## Description

This fixes a few bugs I found around extension cleanup and settings restoration.

### What changed

* Avoid crashing on GNOME 48/49 when workspace animations use `WorkspaceBackground`, which is only available in newer GNOME Shell versions.
* Keep the workspace animation preference in sync when an unsupported option gets reset.
* Avoid restoring old keybindings if the user changed them while O-Tiling was enabled.
* Handle equivalent shortcut modifier names such as `<Alt>` / `<Mod1>` and `<Ctrl>` / `<Control>`.
* Avoid overwriting titlebar button layout changes made by the user while the extension is running.
* Clean up the deferred OSK startup signal if the extension is disabled before Shell finishes starting.

GNOME 50 workspace animation behavior should stay unchanged.