### PR TITLE
Keep the extension loaded across the lock screen, and keep its UI off it

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -8,6 +8,10 @@
         "49",
         "50"
     ],
+    "session-modes": [
+        "user",
+        "unlock-dialog"
+    ],
     "author": "oliwebd",
     "url": "https://github.com/oliwebd/o-tiling"
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -68,6 +68,7 @@ export let ext: Ext | null = null;
 export let indicator: Indicator | null = null;
 export let workspace_number_indicator: WorkspaceNumberIndicator | null = null;
 export let quick_settings_indicator: any = null;
+let lock_screen_ui_signal = 0;
 
 const { cursor_rect, is_keyboard_op, is_resize_op, is_move_op } = Lib;
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
@@ -3828,6 +3829,35 @@ export default class OTilingExtension extends Extension {
         _toggle_workspace_number_indicator(ext.settings.workspace_number_indicator());
         _toggle_quick_settings_indicator(ext.settings.quick_settings_toggle());
 
+        // Lock-screen hygiene: session-modes keeps the extension loaded through the
+        // lock screen (so the tiling forest survives lock/unlock), so nothing of its
+        // UI may be usable there. Hide the panel button, the workspace-number
+        // switcher and the Quick Settings toggle while locked, leave any
+        // interactive mode, pull the panel-transparency stylesheet (its #panel rule
+        // is !important and would paint the lock screen), restore all on unlock.
+        if (!lock_screen_ui_signal) {
+            const applyLockState = () => {
+                const locked = sessionMode.isLocked;
+                if (indicator?.button)
+                    indicator.button.visible = !locked && !ext!.settings.hide_panel_icon();
+                if (workspace_number_indicator?.button)
+                    workspace_number_indicator.button.visible = !locked;
+                if (quick_settings_indicator) {
+                    quick_settings_indicator.visible = !locked;
+                    for (const item of quick_settings_indicator.quickSettingsItems ?? [])
+                        item.visible = !locked;
+                }
+                if (locked) {
+                    ext!.exit_modes();
+                    ext!.panel_transparency_handler?.disable();
+                } else {
+                    ext!.panel_transparency_handler?.enable();
+                }
+            };
+            lock_screen_ui_signal = sessionMode.connect('updated', applyLockState);
+            applyLockState();
+        }
+
         ext.keybindings.enable(ext.keybindings.global).enable(ext.keybindings.window_focus);
 
         if (ext.settings.tile_by_default()) {
@@ -3868,6 +3898,10 @@ export default class OTilingExtension extends Extension {
             _osk_signal = 0;
         }
 
+        if (lock_screen_ui_signal) {
+            sessionMode.disconnect(lock_screen_ui_signal);
+            lock_screen_ui_signal = 0;
+        }
         delete globalThis.oTilingExtension;
         layoutManager.removeChrome(ext!.overlay as any);
         ext!.destroy();

--- a/src/ui/panel_transparency.ts
+++ b/src/ui/panel_transparency.ts
@@ -108,9 +108,7 @@ export class PanelTransparencyManager {
 /* The main panel bar */
 #panel,
 #panel.solid,
-#panel:overview,
-#panel.login-screen,
-#panel.unlock-screen {
+#panel:overview {
     background-color: rgba(0, 0, 0, ${alpha}) !important;
     background-image: none !important;
     box-shadow: none !important;


### PR DESCRIPTION
## What happens

Lock the screen with a fullscreen window (VS Code) on the active workspace, unlock: every other window has moved down one workspace and the fullscreen one is buried under them. Reproducible with a plain suspend/resume, single monitor, no monitor change. Static workspaces (5), `workspaces-only-on-primary=true`, GNOME Shell 50, o-tiling 2.10.10. It is #42 again.

## Why

`metadata.json` has no `session-modes`, so GNOME Shell disables the extension when the screen locks and re-enables it on unlock. `disable()` destroys the tiling forest; `enable()` rebuilds it from the live windows and re-attaches them to workspaces, which is where they move. With `log-level` 4 the journal shows it directly:

```
13:00:38 o-tiling: [INFO] disable            <- lock
13:01:11 o-tiling: [INFO] enable             <- unlock
13:01:12 o-tiling: [DEBUG] activate: skipping activate_with_focus for code — its workspace 1 != active 0
```

History as far as I can read it: 04b36fa (2026-07-26) added `session-modes` with `unlock-dialog`, 43c1b97 (2026-07-29) removed it; #68 added the `was_locked` short-circuit that pop-shell uses, #69 removed it in favour of rebuilding the layout on re-enable. 2.10.10 therefore has neither, and the rebuild is what moves windows when one of them is fullscreen. pop-shell has the same long-standing reports (pop-os/shell#957, #217).

## The change, in two commits

1. `"session-modes": ["user", "unlock-dialog"]` in `metadata.json`: GNOME never calls `disable()` at lock, the forest is never rebuilt, windows stay where they are.
2. Because the extension now lives on the lock screen, keep its UI off it (this is probably why `session-modes` was dropped on 07-29): while `sessionMode.isLocked`, hide the panel button, the workspace-number switcher and the Quick Settings toggle, leave any interactive mode, and disable the panel-transparency manager so its `!important` `#panel` rule does not paint a dark band over GNOME's transparent unlock panel; restore everything on unlock, disconnect in `disable()`. The login/unlock selectors are also dropped from the stylesheet. Keybindings were already `Shell.ActionMode.NORMAL`, so they do not react on the lock screen; `update_display_configuration` already returns early while locked.

## Verified

GNOME Shell 50.3 (Fedora 44), applied to the installed 2.10.10: after a new login, suspend/resume and lock/unlock cycles with a fullscreen window leave every window in place, the journal shows no `disable`/`enable` at lock, and the lock screen shows only the stock `unlock-dialog` panel (a11y, keyboard, quick settings). `npx tsc --noEmit` clean. Shipped the same way in Margine OS (daniel-g-carrasco/margine-image#388 and #394).