### PR TITLE
fix: exit window management mode on external geometry change

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -683,6 +683,10 @@ export class Ext extends Ecs.System<ExtEvent> {
                         break;
 
                     case WindowEvent.Size:
+                        if (this.tiler.window !== null && Ecs.entity_eq(win.entity, this.tiler.window)) {
+                            this.tiler.exit(this);
+                        }
+
                         if (
                             this.auto_tiler &&
                             !this.should_pause_tiling_for_window(win) &&


### PR DESCRIPTION
While a window is held in Window Management Mode (Tiler.window), o-tiling

never touches its real geometry itself until tile-accept — it only moves

the preview overlay. GNOME's native Super+arrow window-snap shortcuts

(toggle-tiled-left/right) were never overridden, so they can still move

the real window mid-session. The debounced reflow that later picks up

that external geometry change then races the still-open session on the

same tiling tree/overlay state, producing the GObject 'has no handler

with id' corruption and crashing every other extension in the shared

gnome-shell process.

Exit the session immediately when the tracked window's geometry changes

externally, before reflow runs — mirrors the existing guard in

on_destroy() for a window closing mid-edit.

Ref #90