### PR TITLE
Fix:skip maximized fullscreen windows in bsp reconstruct #89

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3782,10 +3782,6 @@ declare global {
 let _osk_signal: SignalID = 0;
 let _osk_startup_signal: SignalID = 0;
 
-// Per-window state by stable_sequence before disable(): workspace and whether it was maximized. Restored on
-// enable() so neither a workspace shift nor a maximized window's full-screen rect gets baked into the rebuilt tree.
-let _window_state_snapshot: Map<number, [workspace: number, was_maximized: boolean]> | null = null;
-
 export default class OTilingExtension extends Extension {
     enable() {
         globalThis.oTilingExtension = this;
@@ -3831,18 +3827,6 @@ export default class OTilingExtension extends Extension {
         ext.injections_add();
         ext.signals_attach();
 
-        const window_state_snapshot = _window_state_snapshot;
-        _window_state_snapshot = null;
-
-        if (window_state_snapshot) {
-            for (const win of ext.windows.values()) {
-                const saved = window_state_snapshot.get(win.meta.get_stable_sequence());
-                if (saved && saved[0] !== win.workspace_id()) {
-                    win.meta.change_workspace_by_index(saved[0], false);
-                }
-            }
-        }
-
         disable_window_attention_handler();
 
         layoutManager.addChrome(ext.overlay as any);
@@ -3869,17 +3853,6 @@ export default class OTilingExtension extends Extension {
 
                 const id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 700, () => {
                     ext?.auto_tile_on(false, false);
-                    if (window_state_snapshot && ext) {
-                        const e = ext;
-                        e.register_fn(() => {
-                            for (const win of e.windows.values()) {
-                                const saved = window_state_snapshot.get(win.meta.get_stable_sequence());
-                                if (saved && saved[1] && !win.is_maximized()) {
-                                    Lib.maximize(win.meta);
-                                }
-                            }
-                        });
-                    }
                     if (ext && ext._timeouts['first_startup_tile'] === id) {
                         ext._timeouts['first_startup_tile'] = null;
                     }
@@ -3903,13 +3876,6 @@ export default class OTilingExtension extends Extension {
     disable() {
 
         log.info('disable');
-
-        _window_state_snapshot = new Map();
-        for (const win of ext!.windows.values()) {
-            const maximized = ext!.auto_tiler != null && win.is_tilable(ext!) && win.is_maximized();
-            _window_state_snapshot.set(win.meta.get_stable_sequence(), [win.workspace_id(), maximized]);
-            if (maximized) Lib.unmaximize(win.meta);
-        }
 
         if (_osk_startup_signal) {
             layoutManager.disconnect(_osk_startup_signal);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3779,6 +3779,10 @@ declare global {
 let _osk_signal: SignalID = 0;
 let _osk_startup_signal: SignalID = 0;
 
+// Per-window state by stable_sequence before disable(): workspace and whether it was maximized. Restored on
+// enable() so neither a workspace shift nor a maximized window's full-screen rect gets baked into the rebuilt tree.
+let _window_state_snapshot: Map<number, [workspace: number, was_maximized: boolean]> | null = null;
+
 export default class OTilingExtension extends Extension {
     enable() {
         globalThis.oTilingExtension = this;
@@ -3824,6 +3828,18 @@ export default class OTilingExtension extends Extension {
         ext.injections_add();
         ext.signals_attach();
 
+        const window_state_snapshot = _window_state_snapshot;
+        _window_state_snapshot = null;
+
+        if (window_state_snapshot) {
+            for (const win of ext.windows.values()) {
+                const saved = window_state_snapshot.get(win.meta.get_stable_sequence());
+                if (saved && saved[0] !== win.workspace_id()) {
+                    win.meta.change_workspace_by_index(saved[0], false);
+                }
+            }
+        }
+
         disable_window_attention_handler();
 
         layoutManager.addChrome(ext.overlay as any);
@@ -3850,6 +3866,17 @@ export default class OTilingExtension extends Extension {
 
                 const id = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 700, () => {
                     ext?.auto_tile_on(false, false);
+                    if (window_state_snapshot && ext) {
+                        const e = ext;
+                        e.register_fn(() => {
+                            for (const win of e.windows.values()) {
+                                const saved = window_state_snapshot.get(win.meta.get_stable_sequence());
+                                if (saved && saved[1] && !win.is_maximized()) {
+                                    Lib.maximize(win.meta);
+                                }
+                            }
+                        });
+                    }
                     if (ext && ext._timeouts['first_startup_tile'] === id) {
                         ext._timeouts['first_startup_tile'] = null;
                     }
@@ -3873,6 +3900,13 @@ export default class OTilingExtension extends Extension {
     disable() {
 
         log.info('disable');
+
+        _window_state_snapshot = new Map();
+        for (const win of ext!.windows.values()) {
+            const maximized = ext!.auto_tiler != null && win.is_tilable(ext!) && win.is_maximized();
+            _window_state_snapshot.set(win.meta.get_stable_sequence(), [win.workspace_id(), maximized]);
+            if (maximized) Lib.unmaximize(win.meta);
+        }
 
         if (_osk_startup_signal) {
             layoutManager.disconnect(_osk_startup_signal);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3294,6 +3294,9 @@ export class Ext extends Ecs.System<ExtEvent> {
             if (!window.is_tilable(this) || !this.is_workspace_tiled(window.workspace_id())) continue;
             if (!window.meta.get_compositor_private() || window.meta.minimized) continue;
 
+            // Skip maximized/fullscreen windows: their rect spans the whole work area and breaks BSP split-search.
+            if (window.is_maximized() || window.meta.is_fullscreen()) continue;
+
             const monitor = window.meta.get_monitor();
             const workspace = window.workspace_id();
             const key = `${monitor},${workspace}`;


### PR DESCRIPTION

Their rect spans the full work area, overlaps every sibling, and breaks
the BSP split-search in reconstruct.ts, which then force-retiles the
whole [monitor, workspace] group (log: "no clean split found... falling
back to sequential tiling"). on_maximize() already detaches these
windows and reflows siblings to fill the gap, re-attaching on
unmaximize: skipping them here just lets reconstruction rely on that
existing behavior instead of fighting it.